### PR TITLE
Define macro in cmake instead of a script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,6 @@ endif ()
 
 message(STATUS "Additional compilation flags: ${CMAKE_CXX_FLAGS}")
 
-# generate a git-version.h with a HEAD commit hash tag
-add_custom_target(
-	gitversion ALL sh git-version.sh > git-version.h
-)
-
 add_subdirectory(src)
 add_subdirectory(tests EXCLUDE_FROM_ALL)
 add_subdirectory(tools)

--- a/git-version.sh
+++ b/git-version.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-GIT_VERSION=`git rev-parse --short=8 HEAD`
-echo "#ifndef _DG_GIT_VERSION_"
-echo "#define _DG_GIT_VERSION_"
-echo " #define GIT_VERSION \"$GIT_VERSION\""
-echo "#endif // _DG_GIT_VERSION_"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,10 @@
 if (LLVM_DG)
 	set(LLVM_LINK_COMPONENTS core engine asmparser bitreader support)
 
+	execute_process(COMMAND git rev-parse --short=8 HEAD OUTPUT_VARIABLE GITVERSION)
+	string(REGEX REPLACE "\n$" "" GITVERSION "${GITVERSION}")
+	add_definitions(-DGIT_VERSION="${GITVERSION}")
+
 	add_executable(llvm-dg-dump llvm-dg-dump.cpp)
 	target_link_libraries(llvm-dg-dump LLVMdg)
 

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -9,7 +9,6 @@
 #error "This code needs LLVM enabled"
 #endif
 
-#include "../git-version.h"
 #include <llvm/Config/llvm-config.h>
 
 #if (LLVM_VERSION_MAJOR != 3)


### PR DESCRIPTION
We can use `execute_process` command in cmake to get current version,
instead of a script and hard code to include the generated head file.
See issue #106.