### PR TITLE
Fix for compile error when using llvm-3.9.0:

### DIFF
--- a/src/llvm/analysis/PostDominators.cpp
+++ b/src/llvm/analysis/PostDominators.cpp
@@ -42,7 +42,8 @@ void LLVMDependenceGraph::computePostDominators(bool addPostDomFrontiers)
         pdtree->runOnFunction(f);
 #else
         PostDominatorTreeAnalysis PDT;
-        pdtree = new PostDominatorTree(PDT.run(f));
+        FunctionAnalysisManager DummyFAM;
+        pdtree = new PostDominatorTree(PDT.run(f, DummyFAM));
 #endif
 
         // add immediate post-dominator edges

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -958,7 +958,11 @@ static uint32_t parseAnnotationOpt(const std::string& opt)
 
 int main(int argc, char *argv[])
 {
+#if LLVM_VERSION_MINOR < 9
     llvm::sys::PrintStackTraceOnErrorSignal();
+#else
+    llvm::sys::PrintStackTraceOnErrorSignal(llvm::StringRef());
+#endif
     llvm::PrettyStackTraceProgram X(argc, argv);
 
     llvm::Module *M = nullptr;


### PR DESCRIPTION
- file 'dg/src/llvm/analysis/PostDominators.cpp': function call 'PDT.run(...)' require 2 argumets(the second is actually not used in its implementation), but only one passed.
- file 'dg/tools/llvm-slicer.cpp': function call ' llvm::sys::PrintStackTraceOnErrorSignal(...)' require one argument, but none is passed.