### PR TITLE
FIX: Segmentation Fault when LLVM instruction has no debug Loc

### DIFF
--- a/tools/llvm-to-source.cpp
+++ b/tools/llvm-to-source.cpp
@@ -46,7 +46,9 @@ static void get_lines_from_module(const Module *M, std::set<unsigned>& lines)
         for (const BasicBlock& B : F) {
             for (const Instruction& I : B) {
                 const DebugLoc& Loc = I.getDebugLoc();
-                lines.insert(Loc.getLine());
+                //Make sure that the llvm istruction has corresponding dbg LOC
+                if (Loc)
+                    lines.insert(Loc.getLine());
             }
         }
     }


### PR DESCRIPTION
 (no '!dbg ...' after instruction). 'Loc.getLine()' would segmentation Fault