### PR TITLE
Add feature to print LOC in source file when printing llvm-dg into dot.

### DIFF
--- a/src/llvm/LLVMDG2Dot.h
+++ b/src/llvm/LLVMDG2Dot.h
@@ -95,6 +95,18 @@ public:
             os << "\\nERR: no BB";
         }
 
+        //Print Location in source file
+        if (const llvm::Instruction *I = llvm::dyn_cast<llvm::Instruction>(val)) {
+            const llvm::DebugLoc& Loc = I->getDebugLoc();
+            if(Loc) {
+                os << "\" labelURL=\"";
+                std::string stmp;
+                llvm::raw_string_ostream ross(stmp);
+                Loc.print(llvm::cast<llvm::raw_ostream>(ross));
+                os << ross.str();
+            }
+        }
+
         return err;
     }
 


### PR DESCRIPTION
In the output dot file, add an attribute on Node that shows the location of the llvm instruction on the original source code (if was compiled with -g option). so the dot file will look like this for a node:

NODE0Xxxxx [label=" store ...." labelURL="src/test.c:30:6" ...]
where the attribute labelURL will show the filename, line number and column number.
labelURL will just be absent if the mapping to source is absent.