### PR TITLE
CMake: fix linking of shared libs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,18 @@ add_library(LLVMpta SHARED
 	llvm/analysis/PointsTo/Globals.cpp
 )
 
-target_link_libraries(LLVMpta PTA)
+target_link_libraries(LLVMpta PUBLIC PTA)
+
+# We need all the symbols with dynamic libs. With static libs, we get errors.
+if (BUILD_SHARED_LIBS)
+	if (${LLVM_PACKAGE_VERSION} VERSION_GREATER "3.4")
+		llvm_map_components_to_libnames(LP_llvm_libs core support)
+	else()
+		llvm_map_components_to_libraries(LP_llvm_libs core support)
+	endif()
+
+	target_link_libraries(LLVMpta PUBLIC ${LP_llvm_libs})
+endif()
 
 add_library(LLVMdg SHARED
 	BBlock.h
@@ -64,7 +75,8 @@ add_library(LLVMdg SHARED
 	llvm/analysis/old/DefMap.cpp
 )
 
-target_link_libraries(LLVMdg LLVMpta RD ${llvm_libs})
+target_link_libraries(LLVMdg PUBLIC LLVMpta RD ${llvm_libs})
+
 install(TARGETS LLVMdg LLVMpta PTA RD
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,7 +21,7 @@ if (LLVM_DG)
 	target_link_libraries(llvm-rd-dump LLVMdg)
 
 	add_executable(llvm-to-source llvm-to-source.cpp)
-	target_link_libraries(llvm-to-source ${llvm_libs})
+	target_link_libraries(llvm-to-source PRIVATE ${llvm_libs})
 
 	install(TARGETS llvm-dg-dump llvm-slicer
 		RUNTIME DESTINATION bin)


### PR DESCRIPTION
Now, I see:
```
src/CMakeFiles/LLVMpta.dir/llvm/analysis/PointsTo/PointerSubgraph.cpp.o: In function `dg::analysis::pta::getMemAllocationFunc(llvm::Function const*) [clone .part.6]':
/home/abuild/rpmbuild/BUILD/dg-0.0+20161130/src/llvm/analysis/PointsTo/PointerSubgraph.cpp:112: undefined reference to `llvm::Value::getName() const'
```
LLVMpta needs LLVMCore. The libs should be better handled per target,
not globally, but let it like this for now.

Also mark them PUBLIC appropriatelly -- we use the libs both in exported
headers and our sources.