### PR TITLE
Fix version checks for LLVM 4, LLVM 5

### DIFF
--- a/src/llvm/LLVMDependenceGraph.cpp
+++ b/src/llvm/LLVMDependenceGraph.cpp
@@ -21,7 +21,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>

--- a/src/llvm/Slicer.h
+++ b/src/llvm/Slicer.h
@@ -11,7 +11,7 @@
 #endif
 
 #include <llvm/Config/llvm-config.h>
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>
@@ -42,7 +42,7 @@ template <typename Val>
 static void dropAllUses(Val *V)
 {
     for (auto I = V->use_begin(), E = V->use_end(); I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
         llvm::Value *use = *I;
 #else
         llvm::Value *use = I->getUser();

--- a/src/llvm/analysis/ControlExpression.h
+++ b/src/llvm/analysis/ControlExpression.h
@@ -5,7 +5,7 @@
 #include <llvm/IR/Module.h>
 
 #include <llvm/Config/llvm-config.h>
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>

--- a/src/llvm/analysis/PointsTo/Globals.cpp
+++ b/src/llvm/analysis/PointsTo/Globals.cpp
@@ -12,7 +12,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -12,7 +12,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>
@@ -1204,7 +1204,7 @@ void LLVMPointerSubgraphBuilder::transitivelyBuildUses(const llvm::Value *val)
     assert(!isa<ConstantInt>(val) && "Tried building uses of constant int");
 
     for (auto I = val->use_begin(), E = val->use_end(); I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
         const llvm::Value *use = *I;
 #else
         const llvm::Value *use = I->getUser();
@@ -1650,7 +1650,7 @@ void LLVMPointerSubgraphBuilder::addArgumentOperands(const llvm::Function *F,
     using namespace llvm;
 
     for (auto I = F->use_begin(), E = F->use_end(); I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
         const Value *use = *I;
 #else
         const Value *use = I->getUser();
@@ -1697,7 +1697,7 @@ void LLVMPointerSubgraphBuilder::addVariadicArgumentOperands(const llvm::Functio
     using namespace llvm;
 
     for (auto I = F->use_begin(), E = F->use_end(); I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
         const Value *use = *I;
 #else
         const Value *use = I->getUser();
@@ -1752,7 +1752,7 @@ void LLVMPointerSubgraphBuilder::addReturnNodeOperand(const llvm::Function *F, P
     using namespace llvm;
 
     for (auto I = F->use_begin(), E = F->use_end(); I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
         const Value *use = *I;
 #else
         const Value *use = I->getUser();

--- a/src/llvm/analysis/PointsTo/Structure.cpp
+++ b/src/llvm/analysis/PointsTo/Structure.cpp
@@ -12,7 +12,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>

--- a/src/llvm/analysis/PostDominators.cpp
+++ b/src/llvm/analysis/PostDominators.cpp
@@ -36,7 +36,7 @@ void LLVMDependenceGraph::computePostDominators(bool addPostDomFrontiers)
         Function& f = *cast<Function>(val);
         PostDominatorTree *pdtree;
 
-#if LLVM_VERSION_MINOR < 9
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 9))
         pdtree = new PostDominatorTree();
         // compute post-dominator tree for this function
         pdtree->runOnFunction(f);

--- a/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.cpp
+++ b/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.cpp
@@ -11,7 +11,7 @@
 #endif
 
 #include <llvm/Config/llvm-config.h>
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
 #else
  #include <llvm/IR/CFG.h>
@@ -265,7 +265,7 @@ static void getLocalVariables(const llvm::Function *F,
                 bool is_address_taken = false;
                 for (auto I = Inst.use_begin(), E = Inst.use_end();
                      I != E; ++I) {
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
                     const llvm::Value *use = *I;
 #else
                     const llvm::Value *use = I->getUser();

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -27,7 +27,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
 
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #else

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -26,7 +26,13 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
+
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#else
 #include <llvm/Bitcode/ReaderWriter.h>
+#endif
 
 #if (__clang__)
 #pragma clang diagnostic pop // ignore -Wunused-parameter

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(module, SMD, context);
 #else
     auto _M = llvm::parseIRFile(module, SMD, context);

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -26,7 +26,12 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
+
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/Bitcode/BitcodeReader.h>
+#else
 #include <llvm/Bitcode/ReaderWriter.h>
+#endif
 
 #if (__clang__)
 #pragma clang diagnostic pop // ignore -Wunused-parameter

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -27,7 +27,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
 
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #else
 #include <llvm/Bitcode/ReaderWriter.h>

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(module, SMD, context);
 #else
     auto _M = llvm::parseIRFile(module, SMD, context);

--- a/tools/llvm-pta-compare.cpp
+++ b/tools/llvm-pta-compare.cpp
@@ -24,7 +24,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
 
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #else
 #include <llvm/Bitcode/ReaderWriter.h>

--- a/tools/llvm-pta-compare.cpp
+++ b/tools/llvm-pta-compare.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(module, SMD, context);
 #else
     auto _M = llvm::parseIRFile(module, SMD, context);

--- a/tools/llvm-pta-compare.cpp
+++ b/tools/llvm-pta-compare.cpp
@@ -23,7 +23,12 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
+
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/Bitcode/BitcodeReader.h>
+#else
 #include <llvm/Bitcode/ReaderWriter.h>
+#endif
 
 #if (__clang__)
 #pragma clang diagnostic pop // ignore -Wunused-parameter

--- a/tools/llvm-rd-dump.cpp
+++ b/tools/llvm-rd-dump.cpp
@@ -26,7 +26,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
 
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #else

--- a/tools/llvm-rd-dump.cpp
+++ b/tools/llvm-rd-dump.cpp
@@ -25,7 +25,13 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
+
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#else
 #include <llvm/Bitcode/ReaderWriter.h>
+#endif
 
 #if (__clang__)
 #pragma clang diagnostic pop // ignore -Wunused-parameter

--- a/tools/llvm-rd-dump.cpp
+++ b/tools/llvm-rd-dump.cpp
@@ -284,7 +284,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(module, SMD, context);
 #else
     auto _M = llvm::parseIRFile(module, SMD, context);

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -33,6 +33,13 @@
  #include <llvm/IR/Verifier.h>
 #endif
 
+#if LLVM_VERSION_MAJOR == 4
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#else
+#include <llvm/Bitcode/ReaderWriter.h>
+#endif
+
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -40,7 +47,6 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Support/FormattedStream.h>
 #include <llvm/IRReader/IRReader.h>
-#include <llvm/Bitcode/ReaderWriter.h>
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -139,16 +139,22 @@ llvm::cl::opt<PtaType> pta("pta",
     llvm::cl::values(
         clEnumVal(old , "Old pointer analysis (flow-insensitive, deprecated)"),
         clEnumVal(fi, "Flow-insensitive PTA (default)"),
-        clEnumVal(fs, "Flow-sensitive PTA"),
-        nullptr),
+        clEnumVal(fs, "Flow-sensitive PTA")
+#if LLVM_VERSION_MAJOR < 4
+        , nullptr
+#endif
+        ),
     llvm::cl::init(fi), llvm::cl::cat(SlicingOpts));
 
 llvm::cl::opt<CD_ALG> CdAlgorithm("cd-alg",
     llvm::cl::desc("Choose control dependencies algorithm to use:"),
     llvm::cl::values(
         clEnumValN(CLASSIC , "classic", "Ferrante's algorithm (default)"),
-        clEnumValN(CONTROL_EXPRESSION, "ce", "Control expression based (experimental)"),
-        nullptr),
+        clEnumValN(CONTROL_EXPRESSION, "ce", "Control expression based (experimental)")
+#if LLVM_VERSION_MAJOR < 4
+        , nullptr
+#endif
+         ),
     llvm::cl::init(CLASSIC), llvm::cl::cat(SlicingOpts));
 
 

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -33,7 +33,7 @@
  #include <llvm/IR/Verifier.h>
 #endif
 
-#if LLVM_VERSION_MAJOR == 4
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #else
@@ -913,7 +913,7 @@ static bool verify_module(llvm::Module *M)
     // the verifyModule function returns false if there
     // are no errors
 
-#if ((LLVM_VERSION_MAJOR == 4) || (LLVM_VERSION_MINOR >= 5))
+#if ((LLVM_VERSION_MAJOR >= 4) || (LLVM_VERSION_MINOR >= 5))
     return !llvm::verifyModule(*M, &llvm::errs());
 #else
     return !llvm::verifyModule(*M, llvm::PrintMessageAction);

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -12,7 +12,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MAJOR != 3)
+#if (LLVM_VERSION_MAJOR < 3)
 #error "Unsupported version of LLVM"
 #endif
 
@@ -25,7 +25,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
-#if LLVM_VERSION_MINOR < 5
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Assembly/AssemblyAnnotationWriter.h>
  #include <llvm/Analysis/Verifier.h>
 #else // >= 3.5
@@ -901,7 +901,7 @@ static bool verify_module(llvm::Module *M)
     // the verifyModule function returns false if there
     // are no errors
 
-#if (LLVM_VERSION_MINOR >= 5)
+#if ((LLVM_VERSION_MAJOR == 4) || (LLVM_VERSION_MINOR >= 5))
     return !llvm::verifyModule(*M, &llvm::errs());
 #else
     return !llvm::verifyModule(*M, llvm::PrintMessageAction);
@@ -1019,7 +1019,7 @@ static uint32_t parseAnnotationOpt(const std::string& annot)
 
 int main(int argc, char *argv[])
 {
-#if LLVM_VERSION_MINOR < 9
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 9
     llvm::sys::PrintStackTraceOnErrorSignal();
 #else
     llvm::sys::PrintStackTraceOnErrorSignal(llvm::StringRef());
@@ -1076,7 +1076,7 @@ int main(int argc, char *argv[])
     if (dump_dg_only)
         dump_dg = true;
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(llvmfile, SMD, context);
 #else
     auto _M = llvm::parseIRFile(llvmfile, SMD, context);

--- a/tools/llvm-to-source.cpp
+++ b/tools/llvm-to-source.cpp
@@ -21,7 +21,7 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/DebugInfo.h>
 #else
  #include <llvm/DebugInfo/DIContext.h>
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     if (argc == 3)
         source = argv[2];
 
-#if (LLVM_VERSION_MINOR < 5)
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
     M = llvm::ParseIRFile(module, SMD, context);
 #else
     auto _M = llvm::parseIRFile(module, SMD, context);


### PR DESCRIPTION
Here are some changes to accommodate newer versions of LLVM, most importantly 4.0 which was just branched off.

Mostly it's just changing version preprocessor checks and handling some moved includes.

I've been using these patches to build dg against LLVM trunk for a month or two and it seems to work (lit tests passing at least).