### PR TITLE
Fix LLVM version checks for "> 3.5".

### DIFF
--- a/src/llvm/LLVMDG2Dot.h
+++ b/src/llvm/LLVMDG2Dot.h
@@ -101,7 +101,8 @@ public:
         // on those versions, fix this :)
         if (const llvm::Instruction *I = llvm::dyn_cast<llvm::Instruction>(val)) {
             const llvm::DebugLoc& Loc = I->getDebugLoc();
-#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR > 5))
+#if ((LLVM_VERSION_MAJOR > 3)\
+      || ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR > 5)))
             if(Loc) {
                 os << "\" labelURL=\"";
                 llvm::raw_os_ostream ross(os);

--- a/tools/llvm-to-source.cpp
+++ b/tools/llvm-to-source.cpp
@@ -54,7 +54,8 @@ static void get_lines_from_module(const Module *M, std::set<unsigned>& lines)
             for (const Instruction& I : B) {
                 const DebugLoc& Loc = I.getDebugLoc();
                 //Make sure that the llvm istruction has corresponding dbg LOC
-#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR > 5))
+#if ((LLVM_VERSION_MAJOR > 3)\
+      || ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR > 5)))
                 if (Loc)
 #else
                 if (Loc.getLine() > 0)


### PR DESCRIPTION
Only the one in LLVMDG2Dot is needed to fix compilation.