### PR TITLE
llvm-slicer: fix incorrect map access

### DIFF
--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -400,8 +400,9 @@ public:
         for (auto& it : getConstructedFunctions()) {
             LLVMDependenceGraph *sub = it.second;
             auto& cb = sub->getBlocks();
-            LLVMBBlock *BB = cb[const_cast<llvm::BasicBlock *>(B)];
-            if (BB) {
+            auto I = cb.find(const_cast<llvm::BasicBlock *>(B));
+            if (I != cb.end()) {
+                LLVMBBlock *BB = I->second;
                 if (opts & (ANNOTATE_POSTDOM | ANNOTATE_CD))
                     os << "  ; BB: " << BB << "\n";
 


### PR DESCRIPTION
Accessing the map with nonexistent key will cause the map creates an new entry which is NULL.
Use find to check if the key existed