### PR TITLE
cleanup: replace all typedefs by C++11 using

### DIFF
--- a/src/ADT/DGContainer.h
+++ b/src/ADT/DGContainer.h
@@ -19,10 +19,10 @@ class DGContainer
 {
 public:
     // XXX use llvm ADTs when available, or BDDs?
-    typedef typename std::set<ValueT> ContainerT;
-    typedef typename ContainerT::iterator iterator;
-    typedef typename ContainerT::const_iterator const_iterator;
-    typedef typename ContainerT::size_type size_type;
+    using ContainerT = typename std::set<ValueT>;
+    using iterator = typename ContainerT::iterator;
+    using const_iterator = typename ContainerT::const_iterator;
+    using size_type = typename ContainerT::size_type;
 
     iterator begin() { return container.begin(); }
     const_iterator begin() const { return container.begin(); }

--- a/src/BBlock.h
+++ b/src/BBlock.h
@@ -24,8 +24,8 @@ template <typename NodeT>
 class BBlock
 {
 public:
-    typedef typename NodeT::KeyType KeyT;
-    typedef typename NodeT::DependenceGraphType DependenceGraphT;
+    using KeyT = typename NodeT::KeyType;
+    using DependenceGraphT = typename NodeT::DependenceGraphType;
 
     struct BBlockEdge {
         BBlockEdge(BBlock<NodeT>* t, uint8_t label = 0)
@@ -69,10 +69,10 @@ public:
         }
     }
 
-    typedef EdgesContainer<BBlock<NodeT>> BBlockContainerT;
+    using BBlockContainerT = EdgesContainer<BBlock<NodeT>>;
     // we don't need labels with predecessors
-    typedef EdgesContainer<BBlock<NodeT>> PredContainerT;
-    typedef DGContainer<BBlockEdge> SuccContainerT;
+    using PredContainerT = EdgesContainer<BBlock<NodeT>>;
+    using SuccContainerT = DGContainer<BBlockEdge>;
 
     SuccContainerT& successors() { return nextBBs; }
     const SuccContainerT& successors() const { return nextBBs; }

--- a/src/DG2Dot.h
+++ b/src/DG2Dot.h
@@ -44,7 +44,7 @@ class DG2Dot
 {
     std::set<const typename DependenceGraph<NodeT>::ContainerType *> dumpedGlobals;
 public:
-    typedef typename NodeT::KeyType KeyT;
+    using KeyT = typename NodeT::KeyType;
 
     DG2Dot<NodeT>(DependenceGraph<NodeT> *dg,
                   uint32_t opts = PRINT_CFG | PRINT_DD | PRINT_CD,

--- a/src/DGParameters.h
+++ b/src/DGParameters.h
@@ -54,10 +54,10 @@ template <typename NodeT>
 class DGParameters
 {
 public:
-    typedef typename NodeT::KeyType KeyT;
-    typedef std::map<KeyT, DGParameter<NodeT>> ContainerType;
-    typedef typename ContainerType::iterator iterator;
-    typedef typename ContainerType::const_iterator const_iterator;
+    using KeyT = typename NodeT::KeyType;
+    using ContainerType = std::map<KeyT, DGParameter<NodeT>>;
+    using iterator = typename ContainerType::iterator;
+    using const_iterator = typename ContainerType::const_iterator;
 
     DGParameters<NodeT>(NodeT *cs = nullptr)
     : vararg(nullptr), BBIn(new BBlock<NodeT>), BBOut(new BBlock<NodeT>), callSite(cs){}

--- a/src/DependenceGraph.h
+++ b/src/DependenceGraph.h
@@ -33,15 +33,15 @@ class DependenceGraph
 {
 public:
     // type of key that is used in nodes
-    typedef typename NodeT::KeyType KeyT;
+    using KeyT = typename NodeT::KeyType;
     // type of this dependence graph - so that we can refer to it in the code
-    typedef typename NodeT::DependenceGraphType DependenceGraphT;
+    using DependenceGraphT = typename NodeT::DependenceGraphType;
 
-    typedef std::map<KeyT, NodeT *> ContainerType;
-    typedef typename ContainerType::iterator iterator;
-    typedef typename ContainerType::const_iterator const_iterator;
+    using ContainerType = std::map<KeyT, NodeT *>;
+    using iterator = typename ContainerType::iterator;
+    using const_iterator = typename ContainerType::const_iterator;
 #ifdef ENABLE_CFG
-    typedef std::map<KeyT, BBlock<NodeT> *> BBlocksMapT;
+    using BBlocksMapT = std::map<KeyT, BBlock<NodeT> *>;
 #endif
 
 private:

--- a/src/Node.h
+++ b/src/Node.h
@@ -25,17 +25,17 @@ template <typename DependenceGraphT, typename KeyT, typename NodeT>
 class Node
 {
 public:
-    typedef EdgesContainer<NodeT> ControlEdgesT;
-    typedef EdgesContainer<NodeT> DependenceEdgesT;
+    using ControlEdgesT = EdgesContainer<NodeT>;
+    using DependenceEdgesT = EdgesContainer<NodeT>;
 
     // to be able to reference the KeyT and DG
-    typedef KeyT KeyType;
-    typedef DependenceGraphT DependenceGraphType;
+    using KeyType = KeyT;
+    using DependenceGraphType = DependenceGraphT;
 
-    typedef typename ControlEdgesT::iterator control_iterator;
-    typedef typename ControlEdgesT::const_iterator const_control_iterator;
-    typedef typename DependenceEdgesT::iterator data_iterator;
-    typedef typename DependenceEdgesT::const_iterator const_data_iterator;
+    using control_iterator = typename ControlEdgesT::iterator;
+    using const_control_iterator = typename ControlEdgesT::const_iterator;
+    using data_iterator = typename DependenceEdgesT::iterator;
+    using const_data_iterator = typename DependenceEdgesT::const_iterator;
 
     Node<DependenceGraphT, KeyT, NodeT>(const KeyT& k,
                                         DependenceGraphT *dg = nullptr)

--- a/src/analysis/Analysis.h
+++ b/src/analysis/Analysis.h
@@ -70,7 +70,7 @@ template <typename NodeT>
 class BBlockAnalysis : public Analysis<BBlock<NodeT>>
 {
 public:
-    typedef BBlock<NodeT> *BBlockPtrT;
+    using BBlockPtrT = BBlock<NodeT> *;
 
     AnalysesAuxiliaryData& getAnalysisData(BBlockPtrT BB)
     {

--- a/src/analysis/BFS.h
+++ b/src/analysis/BFS.h
@@ -54,7 +54,7 @@ class BBlockBFS : public BBlockWalk<NodeT,
                                     QueueFIFO<BBlock<NodeT> *> >
 {
 public:
-    typedef BBlock<NodeT> *BBlockPtrT;
+    using BBlockPtrT = BBlock<NodeT> *;
 
     BBlockBFS<NodeT>(uint32_t fl = 0)
         : BBlockWalk<NodeT, QueueFIFO<BBlock<NodeT> *>>(convertBFSBBFlags(fl)),

--- a/src/analysis/ControlExpression/CENode.h
+++ b/src/analysis/ControlExpression/CENode.h
@@ -36,7 +36,7 @@ public:
         }
     };
 
-    typedef std::set<CENode *, CECmp> VisitsSetT;
+    using VisitsSetT = std::set<CENode *, CECmp>;
 
 protected:
     CENode *parent;

--- a/src/analysis/ControlExpression/CFA.h
+++ b/src/analysis/ControlExpression/CFA.h
@@ -15,7 +15,7 @@ template <typename T>
 class CFANode {
     T label;
 public:
-    typedef std::pair<CFANode<T> *, CENode *> EdgeT;
+    using EdgeT = std::pair<CFANode<T> *, CENode *>;
 
     CFANode<T>(const T& l)
         :label(l) {}

--- a/src/analysis/ControlExpression/ControlExpression.h
+++ b/src/analysis/ControlExpression/ControlExpression.h
@@ -17,7 +17,7 @@ class ControlExpression {
     CENode *root;
 
 public:
-    typedef std::vector<CENode *> CEPath;
+    using CEPath = std::vector<CENode *>;
 
     ControlExpression(CENode *r)
         : root(r) {}

--- a/src/analysis/DFS.h
+++ b/src/analysis/DFS.h
@@ -118,7 +118,7 @@ class BBlockDFS : public BBlockWalk<NodeT,
                                     QueueLIFO<BBlock<NodeT> *> >
 {
 public:
-    typedef BBlock<NodeT> *BBlockPtrT;
+    using BBlockPtrT = BBlock<NodeT> *;
 
     BBlockDFS<NodeT>(uint32_t fl = DFS_BB_CFG)
         : BBlockWalk<NodeT, QueueLIFO<BBlock<NodeT> *>>(convertBBFlags(fl)),

--- a/src/analysis/DataFlowAnalysis.h
+++ b/src/analysis/DataFlowAnalysis.h
@@ -115,8 +115,8 @@ private:
     // because the BB's newly added does have dfsorder unset
     // and the BlocksSet thinks it already contains it, so
     // it is not added
-    typedef std::set<BBlock<NodeT> * /*,
-                     DFSOrderLess<BBlock<NodeT> *>*/> BlocksSetT;
+    using BlocksSetT = std::set<BBlock<NodeT> * /*,
+                     DFSOrderLess<BBlock<NodeT> *>*/>;
     struct DFSDataT
     {
         DFSDataT(BlocksSetT& b, bool& c, BBlockDataFlowAnalysis<NodeT> *r)

--- a/src/analysis/NodesWalk.h
+++ b/src/analysis/NodesWalk.h
@@ -249,7 +249,7 @@ template <typename NodeT, typename QueueT>
 class BBlockWalk : public BBlockWalkBase<NodeT>
 {
 public:
-    typedef dg::BBlock<NodeT> *BBlockPtrT;
+    using BBlockPtrT = dg::BBlock<NodeT> *;
 
     BBlockWalk<NodeT, QueueT>(uint32_t fl = BBLOCK_WALK_CFG)
         : flags(fl) {}

--- a/src/analysis/PointsTo/Pointer.h
+++ b/src/analysis/PointsTo/Pointer.h
@@ -49,10 +49,10 @@ struct Pointer
     bool isValid() const { return !isNull() && !isUnknown(); }
 };
 
-typedef std::set<Pointer> PointsToSetT;
-typedef std::map<Offset, PointsToSetT> PointsToMapT;
-typedef std::set<PSNode *> ValuesSetT;
-typedef std::map<Offset, ValuesSetT> ValuesMapT;
+using PointsToSetT = std::set<Pointer>;
+using PointsToMapT = std::map<Offset, PointsToSetT>;
+using ValuesSetT = std::set<PSNode *>;
+using ValuesMapT = std::map<Offset, ValuesSetT>;
 
 struct MemoryObject
 {

--- a/src/analysis/PointsTo/PointsToFlowSensitive.h
+++ b/src/analysis/PointsTo/PointsToFlowSensitive.h
@@ -13,8 +13,8 @@ namespace pta {
 class PointsToFlowSensitive : public PointerAnalysis
 {
 public:
-    typedef std::set<MemoryObject *> MemoryObjectsSetT;
-    typedef std::map<const Pointer, MemoryObjectsSetT> MemoryMapT;
+    using MemoryObjectsSetT = std::set<MemoryObject *>;
+    using MemoryMapT = std::map<const Pointer, MemoryObjectsSetT>;
 
     // this is an easy but not very efficient implementation,
     // works for testing

--- a/src/analysis/ReachingDefinitions/RDMap.h
+++ b/src/analysis/ReachingDefinitions/RDMap.h
@@ -120,14 +120,14 @@ public:
 
 };
 
-typedef std::set<DefSite> DefSiteSetT;
+using DefSiteSetT = std::set<DefSite>;
 
 class RDMap
 {
 public:
-    typedef std::map<DefSite, RDNodesSet> MapT;
-    typedef MapT::iterator iterator;
-    typedef MapT::const_iterator const_iterator;
+    using MapT = std::map<DefSite, RDNodesSet>;
+    using iterator = MapT::iterator;
+    using const_iterator = MapT::const_iterator;
 
     RDMap() {}
     RDMap(const RDMap& o);

--- a/src/analysis/SCC.h
+++ b/src/analysis/SCC.h
@@ -16,8 +16,8 @@ namespace analysis {
 template <typename NodeT>
 class SCC {
 public:
-    typedef std::vector<NodeT *> SCC_component_t;
-    typedef std::vector<SCC_component_t> SCC_t;
+    using SCC_component_t = std::vector<NodeT *>;
+    using SCC_t = std::vector<SCC_component_t>;
 
     SCC<NodeT>() : index(0) {}
 
@@ -95,8 +95,8 @@ private:
 
 template <typename NodeT>
 class SCCCondensation {
-    typedef typename SCC<NodeT>::SCC_t SCC_t;
-    typedef typename SCC<NodeT>::SCC_component_t SCC_component_t;
+    using SCC_t = typename SCC<NodeT>::SCC_t;
+    using SCC_component_t = typename SCC<NodeT>::SCC_component_t;
 
     struct Node {
         const SCC_component_t& component;

--- a/src/llvm/LLVMDependenceGraph.h
+++ b/src/llvm/LLVMDependenceGraph.h
@@ -39,7 +39,7 @@ enum CD_ALG {
 // forward declaration
 class LLVMPointerAnalysis;
 
-typedef dg::BBlock<LLVMNode> LLVMBBlock;
+using LLVMBBlock = dg::BBlock<LLVMNode>;
 
 /// ------------------------------------------------------------------
 //  -- LLVMDependenceGraph

--- a/src/llvm/LLVMNode.h
+++ b/src/llvm/LLVMNode.h
@@ -38,9 +38,9 @@ namespace dg {
 class LLVMDependenceGraph;
 class LLVMNode;
 
-typedef dg::BBlock<LLVMNode> LLVMBBlock;
-typedef dg::DGParameter<LLVMNode> LLVMDGParameter;
-typedef dg::DGParameters<LLVMNode> LLVMDGParameters;
+using LLVMBBlock = dg::BBlock<LLVMNode>;
+using LLVMDGParameter = dg::DGParameter<LLVMNode>;
+using LLVMDGParameters = dg::DGParameters<LLVMNode>;
 
 /// ------------------------------------------------------------------
 //  -- LLVMNode

--- a/src/llvm/analysis/ControlExpression.h
+++ b/src/llvm/analysis/ControlExpression.h
@@ -16,8 +16,8 @@
 
 namespace dg {
 
-typedef CFA<llvm::BasicBlock *> LLVMCFA;
-typedef CFANode<llvm::BasicBlock *> LLVMCFANode;
+using LLVMCFA = CFA<llvm::BasicBlock *>;
+using LLVMCFANode = CFANode<llvm::BasicBlock *>;
 
 class LLVMCFABuilder {
 

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.h
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.h
@@ -15,7 +15,7 @@ namespace dg {
 namespace analysis {
 namespace pta {
 
-typedef std::pair<PSNode *, PSNode *> PSNodesSeq;
+using PSNodesSeq = std::pair<PSNode *, PSNode *>;
 
 class LLVMPointerSubgraphBuilder
 {

--- a/tests/test-dg.h
+++ b/tests/test-dg.h
@@ -19,7 +19,7 @@ public:
 };
 
 #ifdef ENABLE_CFG
-typedef BBlock<TestNode> TestBBlock;
+using TestBBlock = BBlock<TestNode>;
 #endif // ENABLE_CFG
 
 class TestDG : public DependenceGraph<TestNode>


### PR DESCRIPTION
Hi, I made a little cleanup of those C-style `typedef`s, mostly in custom data structures.
This commit replaces all `typedef`s by modern C++11 `using`.