### PR TITLE
LLVMDG2Dot.h: Fix DebugInfo include on 3.5

### DIFF
--- a/src/llvm/LLVMDG2Dot.h
+++ b/src/llvm/LLVMDG2Dot.h
@@ -6,8 +6,10 @@
 #include "DG2Dot.h"
 #include "llvm/LLVMNode.h"
 
-#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR <= 6))
+#if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR <= 4))
 #include "llvm/DebugInfo.h"     //DIScope
+#else
+#include "llvm/IR/DebugInfo.h"     //DIScope
 #endif
 
 using namespace dg;


### PR DESCRIPTION
Slightly change behavior to include equivalent header on 3.6+
for consistency and include-what-you-use.

Motivation/discussion: https://github.com/mchalupa/dg/pull/147/commits/373e01569af6dcdb02f74ea03b0402627d57393f#r115982753

Works for me on 3.4, 3.5, 3.7, 3.8, 3.9, 4.0.

(I'm really not sure why I don't include 3.6 in the set for simplicity's sake!)