### PR TITLE
PointsTo: fix gcc7 warnings

### DIFF
--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -514,6 +514,7 @@ static PSNode *createDynamicAlloc(const llvm::CallInst *CInst, int type)
     switch (type) {
         case MALLOC:
             node->setIsHeap();
+            /* fallthrough */
         case ALLOCA:
             op = CInst->getOperand(0);
             break;
@@ -1459,6 +1460,7 @@ bool LLVMPointerSubgraphBuilder::isRelevantInstruction(const llvm::Instruction& 
             // so we must use this hack (the same with store)
             if (tryGetOperand(Inst.getOperand(0)) != UNKNOWN_MEMORY)
                 return true;
+            /* fallthrough */
         case Instruction::Select:
         case Instruction::PHI:
             // here we don't care about intToPtr, because every such


### PR DESCRIPTION
**Check if both are really OK!**


Gcc 7 warns about missing breaks in switch statements like:
```
src/llvm/analysis/PointsTo/PointerSubgraph.cpp: In function ‘dg::analysis::pta::PSNode* dg::analysis::pta::createDynamicAlloc(const llvm::CallInst*, int)’:
src/llvm/analysis/PointsTo/PointerSubgraph.cpp:516:28: warning: this statement may fall through [-Wimplicit-fallthrough=]
             node->setIsHeap();
             ~~~~~~~~~~~~~~~^~
src/llvm/analysis/PointsTo/PointerSubgraph.cpp:517:9: note: here
         case ALLOCA:
         ^~~~
```
Annotate both of the occurences by "/* fallthrough */" which the
compiler understands as this is intentional no-break.