### PR TITLE
change enums to scoped enums

### DIFF
--- a/src/analysis/ControlExpression/CENode.h
+++ b/src/analysis/ControlExpression/CENode.h
@@ -9,8 +9,8 @@
 
 namespace dg {
 
-enum CENodeType {
-        LABEL  = 1,
+enum class CENodeType {
+        LABEL,
         SEQ,
         BRANCH,
         LOOP,
@@ -29,8 +29,8 @@ public:
     struct CECmp {
         bool operator()(const CENode *a, const CENode *b) const
         {
-            assert(a->isa(LABEL));
-            assert(b->isa(LABEL));
+            assert(a->isa(CENodeType::LABEL));
+            assert(b->isa(CENodeType::LABEL));
 
             return a->lt(b);
         }
@@ -90,11 +90,11 @@ public:
             if (node == nullptr)
                 return;
 
-            if (node->isa(LOOP)) {
+            if (node->isa(CENodeType::LOOP)) {
                 // when the node is loop, we want it in the path,
                 // since the loop is where the execution continues
                 node = *it;
-            } else if (node->parent && node->parent->isa(BRANCH)) {
+            } else if (node->parent && node->parent->isa(CENodeType::BRANCH)) {
                 // is the node's parent a BRANCH? In that case
                 // we must move up again
                 moveUp();
@@ -141,7 +141,7 @@ public:
             if (node->parent) {
                 // in SEQ and LOOPs we shift just to the right,
                 // but in BRANCH we shift _up_
-                if (node->parent->isa(BRANCH)) {
+                if (node->parent->isa(CENodeType::BRANCH)) {
                         moveUp();
                 } else {
                     ++it;
@@ -389,8 +389,8 @@ public:
             // this node. Also, if this is a loop and
             // it contains SEQ, we can make the SEQ
             // just a children of the loop
-            if ((*I)->type == SEQ &&
-                (type == SEQ || type == LOOP)) {
+            if ((*I)->type == CENodeType::SEQ &&
+                (type == CENodeType::SEQ || type == CENodeType::LOOP)) {
                     // we over-take the children,
                     for (CENode *chld : (*I)->children) {
                         new_children.push_back(chld);
@@ -404,7 +404,7 @@ public:
 
                     // now we can delete the memory
                     delete *I;
-            } else if ((*I)->type == SEQ && (*I)->children.size() == 1) {
+            } else if ((*I)->type == CENodeType::SEQ && (*I)->children.size() == 1) {
                     // eliminate sequence when there is only one node in it
 
                     CENode *chld = *((*I)->children.begin());
@@ -419,7 +419,7 @@ public:
 
                     // now we can delete the memory
                     delete *I;
-            } else if (type == SEQ && (*I)->type == EPS) {
+            } else if (type == CENodeType::SEQ && (*I)->type == CENodeType::EPS) {
                 // skip epsilons in SEQuences
                 // (and since we drop the pointer,
                 // release the memory)
@@ -447,7 +447,7 @@ public:
         return [](const CENode *nd) -> CENode * {
             CENode *par = nd->getParent();
             if (par) {
-                if (par->isa(LOOP))
+                if (par->isa(CENodeType::LOOP))
                     return par;
                 else
                     return par->getParentLoop();
@@ -471,7 +471,7 @@ public:
 
     virtual bool lt(const CENode *n) const override
     {
-        if (n->isa(LABEL))
+        if (n->isa(CENodeType::LABEL))
             return label < static_cast<const CELabel<T> *>(n)->label;
         else
             return this < n;

--- a/src/analysis/ControlExpression/CFA.h
+++ b/src/analysis/ControlExpression/CFA.h
@@ -58,7 +58,7 @@ public:
             if (I->first == succ.first) {
                 // if the label already is a branch, just
                 // add new branch to it (take over the ownership)
-                if (I->second->isa(BRANCH)) {
+                if (I->second->isa(CENodeType::BRANCH)) {
                     I->second->addChild(succ.second);
                 } else {
                     CEBranch *br = new CEBranch();

--- a/src/analysis/ControlExpression/ControlExpression.h
+++ b/src/analysis/ControlExpression/ControlExpression.h
@@ -86,7 +86,7 @@ public:
 
                 // XXX: Consider selective termination
                 // every loop may non-terminate, so every loop terminates a path
-                if ((*I)->isa(LOOP))
+                if ((*I)->isa(CENodeType::LOOP))
                     // copy the path that is terminated with this loop
                     paths.push_back(CEPath(P));
 
@@ -109,7 +109,7 @@ public:
         bool found_loop = false;
 
         for (CENode *nd : path) {
-            if (nd->isa(LOOP))
+            if (nd->isa(CENodeType::LOOP))
                 found_loop = true;
 
             // in the case we compute termination sensitive

--- a/src/analysis/ReachingDefinitions/RDMap.cpp
+++ b/src/analysis/ReachingDefinitions/RDMap.cpp
@@ -105,7 +105,7 @@ bool RDMap::merge(const RDMap *oth,
                 // merging this definition into our map
                 if (overwrites_whole_memory)
                     continue;
-            } else if (ds.target->getType() != DYN_ALLOC) {
+            } else if (ds.target->getType() != RDNodeType::DYN_ALLOC) {
                 bool skip = false;
                 auto range = std::equal_range(no_update->begin(),
                                               no_update->end(),

--- a/src/analysis/ReachingDefinitions/ReachingDefinitions.h
+++ b/src/analysis/ReachingDefinitions/ReachingDefinitions.h
@@ -22,13 +22,13 @@ class ReachingDefinitionsAnalysis;
 
 // here the types are for type-checking (optional - user can do it
 // when building the graph) and for later optimizations
-enum RDNodeType {
+enum class RDNodeType {
         // for backward compatibility
-        NONE = 0,
+        NONE,
         // these are nodes that just represent memory allocation sites
         // we need to have them even in reaching definitions analysis,
         // so that we can use them as targets in DefSites
-        ALLOC = 1,
+        ALLOC,
         STORE,
         DYN_ALLOC,
         PHI,
@@ -51,7 +51,7 @@ class RDNode : public SubgraphNode<RDNode> {
     unsigned int dfsid;
 public:
 
-    RDNode(RDNodeType t = NONE) : type(t), dfsid(0) {}
+    RDNode(RDNodeType t = RDNodeType::NONE) : type(t), dfsid(0) {}
 
     // this is the gro of this node, so make it public
     DefSiteSetT defs;

--- a/src/llvm/LLVMDependenceGraph.cpp
+++ b/src/llvm/LLVMDependenceGraph.cpp
@@ -844,7 +844,7 @@ void LLVMDependenceGraph::computeControlExpression(bool addCDs)
                 if (B.getTerminator()->getNumSuccessors() > 1) {
                     auto CS = CE.getControlScope(&B);
                     for (auto cs : CS) {
-                        assert(cs->isa(LABEL));
+                        assert(cs->isa(CENodeType::LABEL));
                         auto lab = static_cast<CELabel<llvm::BasicBlock *> *>(cs);
                         LLVMBBlock *B2 = our_blocks[lab->getLabel()];
                         B1->addControlDependence(B2);

--- a/src/llvm/LLVMDependenceGraph.h
+++ b/src/llvm/LLVMDependenceGraph.h
@@ -29,7 +29,7 @@ namespace llvm {
 
 namespace dg {
 
-enum CD_ALG {
+enum class CD_ALG {
     // Ferrante & Ottenstein
     CLASSIC,
     // our algorithm
@@ -104,12 +104,12 @@ public:
 
     void makeSelfLoopsControlDependent();
 
-    void computeControlDependencies(enum CD_ALG alg_type)
+    void computeControlDependencies(CD_ALG alg_type)
     {
-        if (alg_type == CLASSIC) {
+        if (alg_type == CD_ALG::CLASSIC) {
             computePostDominators(true);
             //makeSelfLoopsControlDependent();
-        } else if (alg_type == CONTROL_EXPRESSION) {
+        } else if (alg_type == CD_ALG::CONTROL_EXPRESSION) {
             computeControlExpression(true);
         } else
             abort();

--- a/src/llvm/analysis/DefUse.cpp
+++ b/src/llvm/analysis/DefUse.cpp
@@ -227,7 +227,7 @@ void LLVMDefUseAnalysis::addUnknownDataDependence(LLVMNode *node, PSNode *pts)
         RDNode *rdnode = it.second;
 
         // only STORE may be a definition site
-        if (rdnode->getType() != analysis::rd::STORE)
+        if (rdnode->getType() != analysis::rd::RDNodeType::STORE)
             continue;
 
         llvm::Value *rdVal = rdnode->getUserData<llvm::Value>();

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     const char *slicing_criterion = nullptr;
     const char *dump_func_only = nullptr;
     const char *pts = "fi";
-    CD_ALG cd_alg = CLASSIC;
+    CD_ALG cd_alg = CD_ALG::CLASSIC;
 
     using namespace debug;
     uint32_t opts = PRINT_CFG | PRINT_DD | PRINT_CD;
@@ -100,9 +100,9 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "-cd-alg") == 0) {
             const char *arg = argv[++i];
             if (strcmp(arg, "classic") == 0)
-                cd_alg = CLASSIC;
+                cd_alg = CD_ALG::CLASSIC;
             else if (strcmp(arg, "ce") == 0)
-                cd_alg = CONTROL_EXPRESSION;
+                cd_alg = CD_ALG::CONTROL_EXPRESSION;
             else {
                 errs() << "Invalid control dependencies algorithm, try: classic, ce\n";
                 abort();

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -148,13 +148,13 @@ llvm::cl::opt<PtaType> pta("pta",
 llvm::cl::opt<CD_ALG> CdAlgorithm("cd-alg",
     llvm::cl::desc("Choose control dependencies algorithm to use:"),
     llvm::cl::values(
-        clEnumValN(CLASSIC , "classic", "Ferrante's algorithm (default)"),
-        clEnumValN(CONTROL_EXPRESSION, "ce", "Control expression based (experimental)")
+        clEnumValN(CD_ALG::CLASSIC , "classic", "Ferrante's algorithm (default)"),
+        clEnumValN(CD_ALG::CONTROL_EXPRESSION, "ce", "Control expression based (experimental)")
 #if LLVM_VERSION_MAJOR < 4
         , nullptr
 #endif
          ),
-    llvm::cl::init(CLASSIC), llvm::cl::cat(SlicingOpts));
+    llvm::cl::init(CD_ALG::CLASSIC), llvm::cl::cat(SlicingOpts));
 
 
 class CommentDBG : public llvm::AssemblyAnnotationWriter


### PR DESCRIPTION
Hi, I changed some of unscoped `enum`s to scoped ones. 

Scoped enums offer better type control and also improve readability of sources, so I believe it is better for these enums to be scoped. As scoped enums are not convertible to numeric types, I did not change enums that are used as flags (flags for BFS or BBlockWalk).

One special enum I did not cover in this patch is `MemAllocationFuncs`. This will be covered in another patch.