### PR TITLE
change MemAllocationFuncs to public enum class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(RD SHARED
 )
 
 add_library(LLVMpta SHARED
+    llvm/MemAllocationFuncs.cpp
 	llvm/analysis/PointsTo/PointsTo.h
 	llvm/analysis/PointsTo/PointerSubgraph.h
 	llvm/analysis/PointsTo/PointerSubgraph.cpp

--- a/src/llvm/MemAllocationFuncs.cpp
+++ b/src/llvm/MemAllocationFuncs.cpp
@@ -1,0 +1,22 @@
+#include "llvm/MemAllocationFuncs.h"
+
+namespace dg {
+
+MemAllocationFuncs getMemAllocationFunc(const llvm::Function *func)
+{
+    if (!func || !func->hasName())
+        return MemAllocationFuncs::NONEMEM;
+
+    const char *name = func->getName().data();
+    if (strcmp(name, "malloc") == 0)
+        return MemAllocationFuncs::MALLOC;
+    else if (strcmp(name, "calloc") == 0)
+        return MemAllocationFuncs::CALLOC;
+    else if (strcmp(name, "alloca") == 0)
+        return MemAllocationFuncs::ALLOCA;
+    else if (strcmp(name, "realloc") == 0)
+        return MemAllocationFuncs::REALLOC;
+
+    return MemAllocationFuncs::NONEMEM;
+}
+}

--- a/src/llvm/MemAllocationFuncs.h
+++ b/src/llvm/MemAllocationFuncs.h
@@ -1,0 +1,20 @@
+#ifndef _DG_MEMALLOCATIONFUNCS_H_
+#define _DG_MEMALLOCATIONFUNCS_H_
+
+#include <llvm/IR/Instructions.h>
+
+namespace dg {
+
+enum class MemAllocationFuncs {
+    NONEMEM,
+    MALLOC,
+    CALLOC,
+    ALLOCA,
+    REALLOC,
+};
+
+MemAllocationFuncs getMemAllocationFunc(const llvm::Function *func);
+}
+
+
+#endif // _DG_MEMALLOCATIONFUNCS_H_

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.h
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.h
@@ -8,6 +8,7 @@
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Constants.h>
 
+#include "llvm/MemAllocationFuncs.h"
 #include "analysis/PointsTo/PointerSubgraph.h"
 #include "analysis/PointsTo/Pointer.h"
 
@@ -218,7 +219,7 @@ private:
     PSNode *createMemTransfer(const llvm::IntrinsicInst *Inst);
 
     PSNodesSeq createMemSet(const llvm::Instruction *);
-    PSNodesSeq createDynamicMemAlloc(const llvm::CallInst *CInst, int type);
+    PSNodesSeq createDynamicMemAlloc(const llvm::CallInst *CInst, MemAllocationFuncs type);
     PSNodesSeq createRealloc(const llvm::CallInst *CInst);
     PSNodesSeq createUnknownCall(const llvm::CallInst *CInst);
     PSNodesSeq createIntrinsic(const llvm::Instruction *Inst);

--- a/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.h
+++ b/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.h
@@ -8,6 +8,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 
+#include "llvm/MemAllocationFuncs.h"
 #include "analysis/ReachingDefinitions/ReachingDefinitions.h"
 #include "llvm/analysis/PointsTo/PointsTo.h"
 
@@ -112,7 +113,7 @@ private:
 
     RDNode *createStore(const llvm::Instruction *Inst);
     RDNode *createAlloc(const llvm::Instruction *Inst);
-    RDNode *createDynAlloc(const llvm::Instruction *Inst, int type);
+    RDNode *createDynAlloc(const llvm::Instruction *Inst, MemAllocationFuncs type);
     RDNode *createRealloc(const llvm::Instruction *Inst);
     RDNode *createReturn(const llvm::Instruction *Inst);
 


### PR DESCRIPTION
Hi, this patch changes `enum MemAllocationFuncs` to scoped enum. 

`MemAllocationFuncs` is also used in more locations, so the type-safety will be useful in this context. I particularly did not like the "hack" where MemAllocationFuncs was passed to `LLVMRDBuilder::createDynAlloc` as `int`, so I decided to patch it this way.

I'm not sure if this is the proper way to achieve it, so I'll be happy to change the patch as requested.