### PR TITLE
MemAllocationFuncs: Add missing include

### DIFF
--- a/src/llvm/MemAllocationFuncs.cpp
+++ b/src/llvm/MemAllocationFuncs.cpp
@@ -1,5 +1,7 @@
 #include "llvm/MemAllocationFuncs.h"
 
+#include <llvm/IR/Function.h>
+
 namespace dg {
 
 MemAllocationFuncs getMemAllocationFunc(const llvm::Function *func)


### PR DESCRIPTION
Required to access `Function::getName()`, without this it fails to compile against 3.5 (and possibly others, didn't check).