### PR TITLE
llvm def-use: improve error message for no RD

### DIFF
--- a/src/llvm/analysis/DefUse.cpp
+++ b/src/llvm/analysis/DefUse.cpp
@@ -47,20 +47,6 @@ using namespace llvm;
 /// --------------------------------------------------
 namespace dg {
 
-static std::string
-getInstName(const llvm::Value *val)
-{
-    std::ostringstream ostr;
-    llvm::raw_os_ostream ro(ostr);
-
-    assert(val);
-    ro << *val;
-    ro.flush();
-
-    // break the string if it is too long
-    return ostr.str();
-}
-
 static void handleInstruction(const Instruction *Inst, LLVMNode *node)
 {
     LLVMDependenceGraph *dg = node->getDG();
@@ -343,8 +329,9 @@ void LLVMDefUseAnalysis::addDataDependence(LLVMNode *node, PSNode *pts,
                 static std::set<const llvm::Value *> reported;
                 if (reported.insert(llvmVal).second) {
                     llvm::errs() << "No reaching definition for: " << *llvmVal;
-                    if (mem->getUserData<llvm::Value>())
-                        llvm::errs() << " in: " << getInstName(mem->getUserData<llvm::Value>());
+                    const llvm::Value *val = mem->getUserData<llvm::Value>();
+                    if (val)
+                        llvm::errs() << " in: " << *val;
                     llvm::errs() << " off: " << *ptr.offset << "\n";
                 }
             }

--- a/src/llvm/analysis/DefUse.cpp
+++ b/src/llvm/analysis/DefUse.cpp
@@ -1,5 +1,4 @@
 #include <map>
-#include <sstream>
 
 // ignore unused parameters in LLVM libraries
 #if (__clang__)


### PR DESCRIPTION
Hi, I have come across this error message many times and it seems to me that the current error message `No reaching definition for: [variable] off: [offset]` isn't very useful as it is, because it doesn't report where the definition is missing. 

This patch improves the error message by adding instruction name from LLVM. This way, one can tell where exactly the definition is missing.