### PR TITLE
cmake: install more headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,9 +83,11 @@ install(FILES
 	analysis/PointsTo/Pointer.h
 	analysis/PointsTo/PointerSubgraph.h
 	analysis/PointsTo/PointsToFlowInsensitive.h
+	analysis/PointsTo/PointsToFlowSensitive.h
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/llvm-dg/analysis/PointsTo/)
 install(FILES
 	llvm/llvm-utils.h
+	llvm/MemAllocationFuncs.h
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/llvm-dg/llvm/)
 install(FILES
 	llvm/analysis/PointsTo/PointerSubgraph.h


### PR DESCRIPTION
They are needed by PointerSubgraph.h and others:
```
llvm/analysis/PointsTo/PointerSubgraph.h:11:10: fatal error: 'llvm/MemAllocationFuncs.h' file not found
...
analyses/points_to_plugin.cpp:6:10: fatal error: 'analysis/PointsTo/PointsToFlowSensitive.h' file not found
```