### PR TITLE
Merge points to analysis with invalidate nodes to dg master 

### DIFF
--- a/src/analysis/PointsTo/Pointer.h
+++ b/src/analysis/PointsTo/Pointer.h
@@ -21,6 +21,7 @@ extern const Pointer PointerUnknown;
 extern const Pointer PointerNull;
 extern PSNode *NULLPTR;
 extern PSNode *UNKNOWN_MEMORY;
+extern PSNode *INVALIDATED;
 
 struct Pointer
 {
@@ -47,6 +48,7 @@ struct Pointer
     bool isNull() const { return target == NULLPTR; }
     bool isUnknown() const { return target == UNKNOWN_MEMORY; };
     bool isValid() const { return !isNull() && !isUnknown(); }
+    bool isInvalidated() const { return target == INVALIDATED; }
 };
 
 using PointsToSetT = std::set<Pointer>;

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -255,18 +255,16 @@ bool PointerAnalysis::processNode(PSNode *node)
                 objects.clear();
                 getMemoryObjects(node, ptr, objects);
                 for (MemoryObject *o : objects) {
-                    if (o->isInvalidated(ptr))
-                        changed |= node->addPointsTo(INVALIDATED);
                     for (const Pointer& to : node->getOperand(0)->pointsTo) {
                         changed |= o->addPointsTo(ptr.offset, to);
-                        if (o->isInvalidated(to))
-                            changed |= node->addPointsTo(INVALIDATED);
                     }
                 }
             }
             break;
         case PSNodeType::FREE:
             for (const Pointer& ptr : node->getOperand(0)->pointsTo) {
+                changed |= node->addPointsTo(INVALIDATED);
+
                 PSNode *target = ptr.target;
                 assert(target && "Got nullptr as target");
 
@@ -274,9 +272,9 @@ bool PointerAnalysis::processNode(PSNode *node)
                     continue;
 
                 objects.clear();
-                getMemoryObjects(node, ptr, objects);
+                getMemoryObjectsPointingTo(node, ptr, objects);
                 for (MemoryObject *o : objects) {
-                    changed |= o->addPointsTo(ptr.offset, INVALIDATED);
+                    changed |= o->addPointsTo(UNKNOWN_OFFSET, INVALIDATED);
                 }
             }
             break;

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -326,6 +326,7 @@ bool PointerAnalysis::processNode(PSNode *node)
         case PSNodeType::CALL:
         case PSNodeType::ENTRY:
         case PSNodeType::NOOP:
+		case PSNodeType::INVALIDATE:
             // just no op
             break;
         default:

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -328,7 +328,7 @@ bool PointerAnalysis::processNode(PSNode *node)
                 if (node->addPointsTo(ptr)) {
                     changed = true;
 
-                    if (ptr.isValid()) {
+                    if (ptr.isValid() && !ptr.isInvalidated()) {
                         functionPointerCall(node, ptr.target);
                     } else {
                         error(node, "Calling invalid pointer as a function!");

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -280,6 +280,8 @@ bool PointerAnalysis::processNode(PSNode *node)
                 }
             }
             break;
+        case PSNodeType::INVALIDATE_LOCALS:
+            break;
         case PSNodeType::GEP:
             for (const Pointer& ptr : node->getOperand(0)->pointsTo) {
                 uint64_t new_offset;

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -272,14 +272,16 @@ bool PointerAnalysis::processNode(PSNode *node)
                 objects.clear();
                 getMemoryObjectsPointingTo(node, ptr, objects);
                 for (MemoryObject *o : objects) {
-                    changed |= o->addPointsTo(UNKNOWN_OFFSET, INVALIDATED);
+                   // changed |= o->addPointsTo(UNKNOWN_OFFSET, INVALIDATED);
                 }
             }
             break;
         case PSNodeType::INVALIDATE_LOCALS:
+            node->setParent(node->getOperand(0)->getSingleSuccessor()->getParent());
             objects.clear();
             getLocalMemoryObjects(node, objects);
             for (MemoryObject *o : objects) {
+                assert(false && "some object here");
                 changed |= o->addPointsTo(UNKNOWN_OFFSET, INVALIDATED);
             }
             break;

--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -263,8 +263,6 @@ bool PointerAnalysis::processNode(PSNode *node)
             break;
         case PSNodeType::FREE:
             for (const Pointer& ptr : node->getOperand(0)->pointsTo) {
-                changed |= node->addPointsTo(INVALIDATED);
-
                 PSNode *target = ptr.target;
                 assert(target && "Got nullptr as target");
 
@@ -279,6 +277,11 @@ bool PointerAnalysis::processNode(PSNode *node)
             }
             break;
         case PSNodeType::INVALIDATE_LOCALS:
+            objects.clear();
+            getLocalMemoryObjects(node, objects);
+            for (MemoryObject *o : objects) {
+                changed |= o->addPointsTo(UNKNOWN_OFFSET, INVALIDATED);
+            }
             break;
         case PSNodeType::GEP:
             for (const Pointer& ptr : node->getOperand(0)->pointsTo) {

--- a/src/analysis/PointsTo/PointerAnalysis.h
+++ b/src/analysis/PointsTo/PointerAnalysis.h
@@ -68,6 +68,13 @@ public:
     virtual void getMemoryObjects(PSNode *where, const Pointer& pointer,
                                   std::vector<MemoryObject *>& objects) = 0;
 
+    virtual void getMemoryObjectsPointingTo(PSNode*, const Pointer&,
+                                            std::vector<MemoryObject *>&)
+    {
+        // this function will be called only by some analyses
+        abort();
+    }
+
     /*
     virtual bool addEdge(MemoryObject *from, MemoryObject *to,
                          Offset off1 = 0, Offset off2 = 0)

--- a/src/analysis/PointsTo/PointerAnalysis.h
+++ b/src/analysis/PointsTo/PointerAnalysis.h
@@ -34,6 +34,9 @@ class PointerAnalysis
     // Flow sensitive flag (contol loop optimization execution)
     bool preprocess_geps;
 
+    // Invalidate flag
+    bool invalidate_nodes;
+
 protected:
     // a set of changed nodes that are going to be
     // processed by the analysis
@@ -42,13 +45,13 @@ protected:
 
     // protected constructor for child classes
     PointerAnalysis() : PS(nullptr), max_offset(UNKNOWN_OFFSET),
-                         preprocess_geps(true) {}
+                         preprocess_geps(true), invalidate_nodes(false) {}
 
 public:
     PointerAnalysis(PointerSubgraph *ps,
                     uint64_t max_off = UNKNOWN_OFFSET,
-                    bool prepro_geps = true)
-    : PS(ps), max_offset(max_off), preprocess_geps(prepro_geps)
+                    bool prepro_geps = true, bool invalid_nodes = false)
+    : PS(ps), max_offset(max_off), preprocess_geps(prepro_geps), invalidate_nodes(invalid_nodes)
     {
         assert(PS && "Need valid PointerSubgraph object");
 

--- a/src/analysis/PointsTo/PointerAnalysis.h
+++ b/src/analysis/PointsTo/PointerAnalysis.h
@@ -79,12 +79,11 @@ public:
         abort();
     }
 
-    // takes a PSNode, an entry node and reference to a vector
+    // takes a PSNode and reference to a vector
     // and fills into the vector the objects that are relevant
     // for the PSNode (valid memory states for of this PSNode)
     // and that point to a stack  
-    virtual void getLocalMemoryObjects(PSNode*, PSNode*,
-                                            std::vector<MemoryObject *>&)
+    virtual void getLocalMemoryObjects(PSNode*, std::vector<MemoryObject *>&)
     {
         // this function will be called only by some analyses
         abort();

--- a/src/analysis/PointsTo/PointerAnalysis.h
+++ b/src/analysis/PointsTo/PointerAnalysis.h
@@ -68,7 +68,22 @@ public:
     virtual void getMemoryObjects(PSNode *where, const Pointer& pointer,
                                   std::vector<MemoryObject *>& objects) = 0;
 
+    // takes a PSNode, a pointer and reference to a vector
+    // and fills into the vector the objects that are relevant
+    // for the PSNode (valid memory states for of this PSNode)
+    // and that point to the pointer  
     virtual void getMemoryObjectsPointingTo(PSNode*, const Pointer&,
+                                            std::vector<MemoryObject *>&)
+    {
+        // this function will be called only by some analyses
+        abort();
+    }
+
+    // takes a PSNode, an entry node and reference to a vector
+    // and fills into the vector the objects that are relevant
+    // for the PSNode (valid memory states for of this PSNode)
+    // and that point to a stack  
+    virtual void getLocalMemoryObjects(PSNode*, PSNode*,
                                             std::vector<MemoryObject *>&)
     {
         // this function will be called only by some analyses

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -58,7 +58,7 @@ enum class PSNodeType {
         // special nodes
         NULL_ADDR,
         UNKNOWN_MEM,
-		// tags memory as invalidated
+        // tags memory as invalidated
         INVALIDATE
 };
 

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -44,7 +44,11 @@ enum class PSNodeType {
         // this is the exit node of a subprocedure
         // that returns a value - works as phi node
         RETURN,
-        // node that freed memory allocated with malloc
+        // node that invalidates allocated memory
+        // after returning from a function
+        INVALIDATE_LOCALS,
+        // node that invalidates memory after calling free
+        // on a pointer
         FREE,
         // node that has only one points-to relation
         // that never changes
@@ -132,6 +136,9 @@ public:
     // RETURN:       represents returning value from a subprocedure,
     //               works as a PHI node - it gathers pointers returned from
     //               the subprocedure
+    // INVALIDATE_LOCALS:
+    //               invalidates memory after returning from a function
+    // FREE:         invalidates memory after calling free function on a pointer
     PSNode(PSNodeType t, ...)
     : SubgraphNode<PSNode>(), type(t), offset(0), pairedNode(nullptr),
       zeroInitialized(false), is_heap(false), is_global(false), dfsid(0)
@@ -185,6 +192,7 @@ public:
                 // UNKNOWN_MEMLOC points to itself
                 pointsTo.insert(Pointer(this, UNKNOWN_OFFSET));
                 break;
+            case PSNodeType::INVALIDATE_LOCALS:
             case PSNodeType::FREE:
                 operands.push_back(va_arg(args, PSNode *));
                 break;

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -83,6 +83,8 @@ class PSNode : public SubgraphNode<PSNode>
     bool zeroInitialized;
     // is memory allocated on heap?
     bool is_heap;
+    // is it a global value?
+    bool is_global;
     unsigned int dfsid;
 public:
     ///
@@ -132,7 +134,7 @@ public:
     //               the subprocedure
     PSNode(PSNodeType t, ...)
     : SubgraphNode<PSNode>(), type(t), offset(0), pairedNode(nullptr),
-      zeroInitialized(false), is_heap(false), dfsid(0)
+      zeroInitialized(false), is_heap(false), is_global(false), dfsid(0)
     {
         // assing operands
         PSNode *op;
@@ -216,6 +218,9 @@ public:
 
     void setIsHeap() { is_heap = true; }
     bool isHeap() const { return is_heap; }
+
+    void setIsGlobal() { is_global = true; }
+    bool isGlobal() { return is_global; }
 
     bool isNull() const { return type == PSNodeType::NULL_ADDR; }
     bool isUnknownMemory() const { return type == PSNodeType::UNKNOWN_MEM; }

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -44,6 +44,8 @@ enum class PSNodeType {
         // this is the exit node of a subprocedure
         // that returns a value - works as phi node
         RETURN,
+        // node that freed memory allocated with malloc
+        FREE,
         // node that has only one points-to relation
         // that never changes
         CONSTANT,
@@ -59,7 +61,7 @@ enum class PSNodeType {
         NULL_ADDR,
         UNKNOWN_MEM,
         // tags memory as invalidated
-        INVALIDATE
+        INVALIDATED
 };
 
 class PSNode : public SubgraphNode<PSNode>
@@ -147,6 +149,7 @@ public:
                 break;
             case PSNodeType::NOOP:
             case PSNodeType::ENTRY:
+            case PSNodeType::INVALIDATED:
                 // no operands
                 break;
             case PSNodeType::CAST:
@@ -180,7 +183,7 @@ public:
                 // UNKNOWN_MEMLOC points to itself
                 pointsTo.insert(Pointer(this, UNKNOWN_OFFSET));
                 break;
-            case PSNodeType::INVALIDATE:
+            case PSNodeType::FREE:
                 operands.push_back(va_arg(args, PSNode *));
                 break;
             case PSNodeType::CALL_RETURN:
@@ -216,6 +219,7 @@ public:
 
     bool isNull() const { return type == PSNodeType::NULL_ADDR; }
     bool isUnknownMemory() const { return type == PSNodeType::UNKNOWN_MEM; }
+    bool isInvalidated() const { return type == PSNodeType::INVALIDATED; }
 
     // make this public, that's basically the only
     // reason the PointerSubgraph node exists, so don't hide it

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -86,7 +86,7 @@ class PSNode : public SubgraphNode<PSNode>
 
     // in some cases we need to know from which function the node is
     // so we need to remember the entry node 
-    PSNode *parent;
+    PSNode *parent = nullptr;
 
     /// some additional information
     // was memory zeroed at initialization or right after allocating?
@@ -225,7 +225,7 @@ public:
     void setOffset(uint64_t o) { offset = o; }
     
     void setParent(PSNode *p) { parent = p; }
-    PSNode* getParent() { return parent; }
+    PSNode *getParent() { return parent; }
 
     PSNode *getPairedNode() const { return pairedNode; }
     void setPairedNode(PSNode *n) { pairedNode = n; }

--- a/src/analysis/PointsTo/PointerSubgraph.h
+++ b/src/analysis/PointsTo/PointerSubgraph.h
@@ -58,6 +58,8 @@ enum class PSNodeType {
         // special nodes
         NULL_ADDR,
         UNKNOWN_MEM,
+		// tags memory as invalidated
+        INVALIDATE
 };
 
 class PSNode : public SubgraphNode<PSNode>
@@ -177,6 +179,9 @@ public:
             case PSNodeType::UNKNOWN_MEM:
                 // UNKNOWN_MEMLOC points to itself
                 pointsTo.insert(Pointer(this, UNKNOWN_OFFSET));
+                break;
+            case PSNodeType::INVALIDATE:
+                operands.push_back(va_arg(args, PSNode *));
                 break;
             case PSNodeType::CALL_RETURN:
             case PSNodeType::PHI:

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -1,0 +1,199 @@
+#ifndef _DG_ANALYSIS_POINTS_TO_WITH_INVALIDATE_H_
+#define _DG_ANALYSIS_POINTS_TO_WITH_INVALIDATE_H_
+
+#include <cassert>
+
+#include "Pointer.h"
+#include "PointerSubgraph.h"
+
+namespace dg {
+namespace analysis {
+namespace pta {
+
+class PointsToWithInvalidate : public PointerAnalysis
+{
+public:
+    using MemoryObjectsSetT = std::set<MemoryObject *>;
+    using MemoryMapT = std::map<const Pointer, MemoryObjectsSetT>;
+
+    // this is an easy but not very efficient implementation,
+    // works for testing
+    PointsToWithInvalidate(PointerSubgraph *ps)
+    : PointerAnalysis(ps, UNKNOWN_OFFSET, false) {}
+
+    static bool canChangeMM(PSNode *n) {
+        if (n->predecessorsNum() == 0 || // root node
+            n->getType() == PSNodeType::STORE ||
+            n->getType() == PSNodeType::MEMCPY ||
+            n->getType() == PSNodeType::FREE ||
+            n->getType() == PSNodeType::CALL_RETURN ||
+            n->getType() == PSNodeType::RETURN)
+            return true;
+
+        return false;
+    }
+
+    bool beforeProcessed(PSNode *n) override
+    {
+        MemoryMapT *mm = n->getData<MemoryMapT>();
+        if (mm)
+            return false;
+
+        bool changed = false;
+
+        // on these nodes the memory map can change
+        if (canChangeMM(n)) { // root node
+            // FIXME: we're leaking the memory maps
+            mm = new MemoryMapT();
+        } else if (n->predecessorsNum() > 1) {
+            // this is a join node, create a new map and
+            // merge the predecessors to it
+            mm = new MemoryMapT();
+
+            // merge information from predecessors into the new map
+            // XXX: this is necessary also with the merge in afterProcess,
+            // because this copies the information even for single
+            // predecessor, whereas afterProcessed copies the
+            // information only for two or more predecessors
+            for (PSNode *p : n->getPredecessors()) {
+                MemoryMapT *pm = p->getData<MemoryMapT>();
+                // merge pm to mm (if pm was already created)
+                if (pm) {
+                    changed |= mergeMaps(mm, pm, nullptr);
+                }
+            }
+        } else {
+            // this node can not change the memory map,
+            // so just add a pointer from the predecessor
+            // to this map
+            PSNode *pred = n->getSinglePredecessor();
+            mm = pred->getData<MemoryMapT>();
+            assert(mm && "No memory map in the predecessor");
+        }
+
+        assert(mm && "Did not create the MM");
+
+        // memory map initialized, set it as data,
+        // so that we won't initialize it again
+        n->setData<MemoryMapT>(mm);
+
+        // ignore any changes here except when we merged some new information.
+        // The other changes we'll detect later
+        return changed;
+    }
+
+    bool afterProcessed(PSNode *n) override
+    {
+        bool changed = false;
+        PointsToSetT *strong_update = nullptr;
+
+        MemoryMapT *mm = n->getData<MemoryMapT>();
+        // we must have the memory map, we created it
+        // in the beforeProcessed method
+        assert(mm && "Do not have memory map");
+
+        // every store is a strong update
+        // FIXME: memcpy can be strong update too
+        if (n->getType() == PSNodeType::STORE)
+            strong_update = &n->getOperand(1)->pointsTo;
+
+        if (n->getType() == PSNodeType::FREE)
+            strong_update = &n->getOperand(0)->pointsTo;
+        
+        if (n->getType() == PSNodeType::CALL_RETURN || n->getType() == PSNodeType::RETURN)
+            strong_update = &n->pointsTo;
+
+
+        // merge information from predecessors if there's
+        // more of them (if there's just one predecessor
+        // and this is not a store, the memory map couldn't
+        // change, so we don't have to do that)
+        if (n->predecessorsNum() > 1 || strong_update
+            || n->getType() == PSNodeType::MEMCPY) {
+            for (PSNode *p : n->getPredecessors()) {
+                MemoryMapT *pm = p->getData<MemoryMapT>();
+                // merge pm to mm (but only if pm was already created)
+                if (pm) {
+                    changed |= mergeMaps(mm, pm, strong_update);
+                }
+            }
+        }
+
+        return changed;
+    }
+
+    void getMemoryObjects(PSNode *where, const Pointer& pointer,
+                          std::vector<MemoryObject *>& objects) override
+    {
+        MemoryMapT *mm= where->getData<MemoryMapT>();
+        assert(mm && "Node does not have memory map");
+
+        auto bounds = getObjectRange(mm, pointer);
+        for (MemoryMapT::iterator I = bounds.first; I != bounds.second; ++I) {
+            assert(I->first.target == pointer.target
+                    && "Bug in getObjectRange");
+
+            for (MemoryObject *mo : I->second)
+                objects.push_back(mo);
+        }
+
+        assert(bounds.second->first.target != pointer.target
+                && "Bug in getObjectRange");
+
+        // if we haven't found any memory object, but this psnode
+        // is a write to memory, create a new one, so that
+        // the write has something to write to
+        if (objects.empty() && canChangeMM(where)) {
+            MemoryObject *mo = new MemoryObject(pointer.target);
+            (*mm)[pointer].insert(mo);
+            objects.push_back(mo);
+        }
+    }
+
+protected:
+
+    PointsToWithInvalidate() = default;
+
+private:
+
+    static bool comp(const std::pair<const Pointer, MemoryObjectsSetT>& a,
+                     const std::pair<const Pointer, MemoryObjectsSetT>& b) {
+        return a.first.target < b.first.target;
+    }
+
+    ///
+    // get interator range for elements that have information
+    // about the ptr.target node (ignoring the offsets)
+    std::pair<MemoryMapT::iterator, MemoryMapT::iterator>
+    getObjectRange(MemoryMapT *mm, const Pointer& ptr) {
+        std::pair<const Pointer, MemoryObjectsSetT> what(ptr, MemoryObjectsSetT());
+        return std::equal_range(mm->begin(), mm->end(), what, comp);
+    }
+
+    ///
+    // Merge two Memory maps, return true if any new information was created,
+    // otherwise return false
+    bool mergeMaps(MemoryMapT *mm, MemoryMapT *pm,
+                   PointsToSetT *strong_update) {
+        bool changed = false;
+        for (auto& it : *pm) {
+            const Pointer& ptr = it.first;
+            if (strong_update && strong_update->count(ptr))
+                continue;
+
+            // use [] to create the object if needed
+            MemoryObjectsSetT& S = (*mm)[ptr];
+            for (auto& elem : it.second)
+                changed |= S.insert(elem).second;
+        }
+
+        return changed;
+    }
+};
+
+} // namespace pta
+} // namespace analysis
+} // namespace dg
+
+#endif // _DG_ANALYSIS_POINTS_TO_WITH_INVALIDATE_H_
+

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -147,6 +147,35 @@ public:
             objects.push_back(mo);
         }
     }
+    
+    void getMemoryObjectsPointingTo(PSNode *where, const Pointer& pointer,
+                          std::vector<MemoryObject *>& objects) override
+    {
+        MemoryMapT *mm= where->getData<MemoryMapT>();
+        assert(mm && "Node does not have memory map");
+
+        for (auto& I : *mm) {
+            for (MemoryObject *mo : I.second) {
+                for (auto& it : mo->pointsTo) {
+                    for (const auto& ptr : it.second) {
+                        if (ptr.target == pointer.target) {
+                            objects.push_back(mo);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // if we haven't found any memory object, but this psnode
+        // is a write to memory, create a new one, so that
+        // the write has something to write to
+        /*if (objects.empty() && canChangeMM(where)) {
+            MemoryObject *mo = new MemoryObject(pointer.target);
+            (*mm)[pointer].insert(mo);
+            objects.push_back(mo);
+        }*/
+    }
 
 protected:
 

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -168,6 +168,29 @@ public:
             }
         }
     }
+    
+    void getLocalMemoryObjects(PSNode *where, 
+                          std::vector<MemoryObject *>& objects) override
+    {
+        MemoryMapT *mm= where->getData<MemoryMapT>();
+        assert(mm && "Node does not have memory map");
+
+        for (auto& I : *mm) {
+            for (MemoryObject *mo : I.second) {
+                for (auto& it : mo->pointsTo) {
+                    for (const auto& ptr : it.second) {
+                        if (!ptr.target->isHeap() &&
+                            !ptr.target->isGlobal() &&
+                            ptr.target->getParent() == where->getParent()) {
+                            objects.push_back(mo);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
 protected:
 

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -19,7 +19,7 @@ public:
     // this is an easy but not very efficient implementation,
     // works for testing
     PointsToWithInvalidate(PointerSubgraph *ps)
-    : PointerAnalysis(ps, UNKNOWN_OFFSET, false) {}
+    : PointerAnalysis(ps, UNKNOWN_OFFSET, false, true) {}
 
     static bool canChangeMM(PSNode *n) {
         if (n->predecessorsNum() == 0 || // root node

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -147,6 +147,7 @@ public:
             objects.push_back(mo);
         }
     }
+   
     
     void getMemoryObjectsPointingTo(PSNode *where, const Pointer& pointer,
                           std::vector<MemoryObject *>& objects) override
@@ -166,15 +167,6 @@ public:
                 }
             }
         }
-
-        // if we haven't found any memory object, but this psnode
-        // is a write to memory, create a new one, so that
-        // the write has something to write to
-        /*if (objects.empty() && canChangeMM(where)) {
-            MemoryObject *mo = new MemoryObject(pointer.target);
-            (*mm)[pointer].insert(mo);
-            objects.push_back(mo);
-        }*/
     }
 
 protected:

--- a/src/analysis/PointsTo/PointsToWithInvalidate.h
+++ b/src/analysis/PointsTo/PointsToWithInvalidate.h
@@ -26,8 +26,7 @@ public:
             n->getType() == PSNodeType::STORE ||
             n->getType() == PSNodeType::MEMCPY ||
             n->getType() == PSNodeType::FREE ||
-            n->getType() == PSNodeType::CALL_RETURN ||
-            n->getType() == PSNodeType::RETURN)
+            n->getType() == PSNodeType::INVALIDATE_LOCALS)
             return true;
 
         return false;
@@ -99,10 +98,9 @@ public:
 
         if (n->getType() == PSNodeType::FREE)
             strong_update = &n->getOperand(0)->pointsTo;
-        
-        if (n->getType() == PSNodeType::CALL_RETURN || n->getType() == PSNodeType::RETURN)
-            strong_update = &n->pointsTo;
 
+        if (n->getType() == PSNodeType::INVALIDATE_LOCALS)
+            strong_update = &n->pointsTo;
 
         // merge information from predecessors if there's
         // more of them (if there's just one predecessor

--- a/src/llvm/LLVMDependenceGraph.cpp
+++ b/src/llvm/LLVMDependenceGraph.cpp
@@ -347,7 +347,7 @@ void LLVMDependenceGraph::handleInstruction(llvm::Value *val,
             PSNode *op = PTA->getNode(strippedValue);
             if (op) {
                 for (const Pointer& ptr : op->pointsTo) {
-                    if (!ptr.isValid())
+                    if (!ptr.isValid() || ptr.isInvalidated())
                         continue;
 
                     // vararg may introduce imprecision here, so we

--- a/src/llvm/analysis/DefUse.cpp
+++ b/src/llvm/analysis/DefUse.cpp
@@ -295,6 +295,9 @@ void LLVMDefUseAnalysis::addDataDependence(LLVMNode *node, PSNode *pts,
         if (!ptr.isValid())
             continue;
 
+        if (ptr.isInvalidated())
+            continue;
+
         llvm::Value *llvmVal = ptr.target->getUserData<llvm::Value>();
         assert(llvmVal && "Don't have Value in PSNode");
 

--- a/src/llvm/analysis/PointsTo/Globals.cpp
+++ b/src/llvm/analysis/PointsTo/Globals.cpp
@@ -113,6 +113,7 @@ PSNodesSeq LLVMPointerSubgraphBuilder::buildGlobals()
 
         // every global node is like memory allocation
         cur = new PSNode(PSNodeType::ALLOC);
+        cur->setIsGlobal();
         addNode(&*I, cur);
 
         if (prev)

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -833,7 +833,7 @@ LLVMPointerSubgraphBuilder::createCall(const llvm::Instruction *Inst)
     if (func) {
         // is it a call to free? If so, create invalidate node
         // instead.
-        if(func->getName().equals("free")) {
+        if(invalidate_nodes && func->getName().equals("free")) {
             PSNode *n = createFree(Inst);
             return std::make_pair(n, n);
         }

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -610,11 +610,6 @@ LLVMPointerSubgraphBuilder::createCallToFunction(const llvm::Function *F)
     for (auto A = F->arg_begin(), E = F->arg_end(); A != E; ++A)
         getOperand(&*A);
 
-    if (invalidate_nodes) {
-        PSNode *invalidateNode = new PSNode(PSNodeType::INVALIDATE);
-        invalidateNode->insertBefore(returnNode);
-    }
-    
     return std::make_pair(callNode, returnNode);
 }
 
@@ -1660,8 +1655,8 @@ void LLVMPointerSubgraphBuilder::addProgramStructure()
         // add the CFG edges
         addProgramStructure(F, subg);
 
-         std::set<PSNode *> cont;
-        getNodes(cont, subg.root, 0xdead);
+        std::set<PSNode *> cont;
+        getNodes(cont, subg.root, subg.ret, 0xdead);
         for (PSNode* n : cont) {
             n->setParent(subg.root);
         }

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -611,12 +611,11 @@ LLVMPointerSubgraphBuilder::createCallToFunction(const llvm::Function *F)
         getOperand(&*A);
 
     if (invalidate_nodes) {
-        PSNode *invalidateNode = new PSNode(PSNodeType::INVALIDATE, returnNode);
+        PSNode *invalidateNode = new PSNode(PSNodeType::INVALIDATE);
         invalidateNode->insertBefore(returnNode);
-        return std::make_pair(callNode, invalidateNode);
-    } else {
-        return std::make_pair(callNode, returnNode);
     }
+    
+    return std::make_pair(callNode, returnNode);
 }
 
 PSNodesSeq
@@ -1648,12 +1647,6 @@ PSNode *LLVMPointerSubgraphBuilder::buildFunction(const llvm::Function& F)
     // built, since the PHI gathers values from different blocks
     addPHIOperands(F);
 
-    std::set<PSNode *> cont;
-    getNodes(cont, root, 0xdead);
-    for (PSNode* n : cont) {
-        n->setParent(root);
-    }
-
     return root;
 }
 
@@ -1666,6 +1659,12 @@ void LLVMPointerSubgraphBuilder::addProgramStructure()
 
         // add the CFG edges
         addProgramStructure(F, subg);
+
+         std::set<PSNode *> cont;
+        getNodes(cont, subg.root, 0xdead);
+        for (PSNode* n : cont) {
+            n->setParent(subg.root);
+        }
 
         // add the missing operands (to arguments and return nodes)
         addInterproceduralOperands(F, subg);

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -1648,6 +1648,12 @@ PSNode *LLVMPointerSubgraphBuilder::buildFunction(const llvm::Function& F)
     // built, since the PHI gathers values from different blocks
     addPHIOperands(F);
 
+    std::set<PSNode *> cont;
+    getNodes(cont, root, 0xdead);
+    for (PSNode* n : cont) {
+        n->setParent(root);
+    }
+
     return root;
 }
 

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.cpp
@@ -802,10 +802,10 @@ LLVMPointerSubgraphBuilder::createAsm(const llvm::Instruction *Inst)
     return n;
 }
 
-PSNode * LLVMPointerSubgraphBuilder::createInvalidate(const llvm::Instruction *Inst)
+PSNode * LLVMPointerSubgraphBuilder::createFree(const llvm::Instruction *Inst)
 {
     PSNode *op1 = getOperand(Inst->getOperand(0));
-    PSNode *node = new PSNode(PSNodeType::INVALIDATE, op1);
+    PSNode *node = new PSNode(PSNodeType::FREE, op1);
 
     addNode(Inst, node);
 
@@ -834,7 +834,7 @@ LLVMPointerSubgraphBuilder::createCall(const llvm::Instruction *Inst)
         // is it a call to free? If so, create invalidate node
         // instead.
         if(func->getName().equals("free")) {
-            PSNode *n = createInvalidate(Inst);
+            PSNode *n = createFree(Inst);
             return std::make_pair(n, n);
         }
         

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.h
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.h
@@ -28,6 +28,9 @@ class LLVMPointerSubgraphBuilder
     // some new parts of already built graph.
     // This is important with function pointer calls
     bool ad_hoc_building = false;
+    // flag that determines whether invalidate nodes
+    // should be created
+    bool invalidate_nodes = false;
 
     // build pointer state subgraph for given graph
     // \return   root node of the graph
@@ -132,6 +135,11 @@ public:
             n = n->getPairedNode();
 
         return n;
+    }
+
+    void setInvalidateNodesFlag(bool value) 
+    {
+        this->invalidate_nodes = value;
     }
 
 private:

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.h
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.h
@@ -170,7 +170,7 @@ private:
     PSNode *createAdd(const llvm::Instruction *Inst);
     PSNode *createArithmetic(const llvm::Instruction *Inst);
     PSNode *createUnknown(const llvm::Value *val);
-    PSNode *createInvalidate(const llvm::Instruction *Inst);
+    PSNode *createFree(const llvm::Instruction *Inst);
 
     PSNode *getOperand(const llvm::Value *val);
     PSNode *tryGetOperand(const llvm::Value *val);

--- a/src/llvm/analysis/PointsTo/PointerSubgraph.h
+++ b/src/llvm/analysis/PointsTo/PointerSubgraph.h
@@ -170,6 +170,7 @@ private:
     PSNode *createAdd(const llvm::Instruction *Inst);
     PSNode *createArithmetic(const llvm::Instruction *Inst);
     PSNode *createUnknown(const llvm::Value *val);
+    PSNode *createInvalidate(const llvm::Instruction *Inst);
 
     PSNode *getOperand(const llvm::Value *val);
     PSNode *tryGetOperand(const llvm::Value *val);

--- a/src/llvm/analysis/PointsTo/PointsTo.h
+++ b/src/llvm/analysis/PointsTo/PointsTo.h
@@ -24,6 +24,7 @@
 #include "analysis/PointsTo/PointerAnalysis.h"
 #include "llvm/llvm-utils.h"
 #include "llvm/analysis/PointsTo/PointerSubgraph.h"
+#include "analysis/PointsTo/PointsToWithInvalidate.h"
 
 namespace dg {
 
@@ -186,6 +187,32 @@ public:
         return new LLVMPointerAnalysisImpl<PTType>(PS, builder);
     }
 };
+
+template <>
+inline void LLVMPointerAnalysis::run<analysis::pta::PointsToWithInvalidate>()
+{
+    // build the subgraph
+    assert(PS && "Incorrectly constructed PTA, missing PS");
+    PS->setRoot(builder->buildLLVMPointerSubgraph());
+
+    // run the analysis itself
+    assert(builder && "Incorrectly constructed PTA, missing builder");
+    builder->setInvalidateNodesFlag(true);
+    LLVMPointerAnalysisImpl<analysis::pta::PointsToWithInvalidate> PTA(PS, builder);
+    PTA.run();
+}
+
+template <>
+inline analysis::pta::PointerAnalysis *LLVMPointerAnalysis::createPTA<analysis::pta::PointsToWithInvalidate>()
+{
+    // build the subgraph
+    assert(PS && "Incorrectly constructed PTA, missing PS");
+    PS->setRoot(builder->buildLLVMPointerSubgraph());
+
+    assert(builder && "Incorrectly constructed PTA, missing builder");
+    builder->setInvalidateNodesFlag(true);
+    return new LLVMPointerAnalysisImpl<analysis::pta::PointsToWithInvalidate>(PS, builder);
+}
 
 } // namespace dg
 

--- a/src/llvm/analysis/PointsTo/PointsTo.h
+++ b/src/llvm/analysis/PointsTo/PointsTo.h
@@ -193,11 +193,11 @@ inline void LLVMPointerAnalysis::run<analysis::pta::PointsToWithInvalidate>()
 {
     // build the subgraph
     assert(PS && "Incorrectly constructed PTA, missing PS");
+    builder->setInvalidateNodesFlag(true);
     PS->setRoot(builder->buildLLVMPointerSubgraph());
 
     // run the analysis itself
     assert(builder && "Incorrectly constructed PTA, missing builder");
-    builder->setInvalidateNodesFlag(true);
     LLVMPointerAnalysisImpl<analysis::pta::PointsToWithInvalidate> PTA(PS, builder);
     PTA.run();
 }
@@ -207,10 +207,10 @@ inline analysis::pta::PointerAnalysis *LLVMPointerAnalysis::createPTA<analysis::
 {
     // build the subgraph
     assert(PS && "Incorrectly constructed PTA, missing PS");
+    builder->setInvalidateNodesFlag(true);
     PS->setRoot(builder->buildLLVMPointerSubgraph());
 
     assert(builder && "Incorrectly constructed PTA, missing builder");
-    builder->setInvalidateNodesFlag(true);
     return new LLVMPointerAnalysisImpl<analysis::pta::PointsToWithInvalidate>(PS, builder);
 }
 

--- a/src/llvm/analysis/PointsTo/PointsTo.h
+++ b/src/llvm/analysis/PointsTo/PointsTo.h
@@ -154,9 +154,9 @@ public:
         return builder->getNodesMap();
     }
 
-    void getNodes(std::set<PSNode *>& cont)
+    std::vector<PSNode *> getNodes()
     {
-        PS->getNodes(cont);
+        return PS->getNodes();
     }
 
     template <typename PTType>

--- a/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.cpp
+++ b/src/llvm/analysis/ReachingDefinitions/ReachingDefinitions.cpp
@@ -303,6 +303,9 @@ RDNode *LLVMRDBuilder::createStore(const llvm::Instruction *Inst)
             continue;
         }
 
+        if (ptr.isInvalidated())
+            continue;
+
         const llvm::Value *ptrVal = ptr.target->getUserData<llvm::Value>();
         // this may emerge with vararg function
         if (llvm::isa<llvm::Function>(ptrVal))
@@ -633,6 +636,9 @@ RDNode *LLVMRDBuilder::createUndefinedCall(const llvm::CallInst *CInst)
             if (!ptr.isValid())
                 continue;
 
+            if (ptr.isInvalidated())
+                continue;
+
             const llvm::Value *ptrVal = ptr.target->getUserData<llvm::Value>();
             if (llvm::isa<llvm::Function>(ptrVal))
                 // function may not be redefined
@@ -694,7 +700,7 @@ RDNode *LLVMRDBuilder::createIntrinsicCall(const llvm::CallInst *CInst)
         len = C->getLimitedValue();
 
     for (const pta::Pointer& ptr : pts->pointsTo) {
-        if (!ptr.isValid())
+        if (!ptr.isValid() || ptr.isInvalidated())
             continue;
 
         const llvm::Value *ptrVal = ptr.target->getUserData<llvm::Value>();
@@ -785,7 +791,7 @@ LLVMRDBuilder::createCall(const llvm::Instruction *Inst)
 
         if (op->pointsTo.size() > 1) {
             for (const pta::Pointer& ptr : op->pointsTo) {
-                if (!ptr.isValid())
+                if (!ptr.isValid() || ptr.isInvalidated())
                     continue;
 
                 // check if it is a function (varargs may

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -51,6 +51,7 @@
 
 #include "analysis/PointsTo/PointsToFlowSensitive.h"
 #include "analysis/PointsTo/PointsToFlowInsensitive.h"
+#include "analysis/PointsTo/PointsToWithInvalidate.h"
 
 using namespace dg;
 using llvm::errs;
@@ -145,6 +146,10 @@ int main(int argc, char *argv[])
     } else if (strcmp(pts, "fi") == 0) {
         tm.start();
         PTA->run<analysis::pta::PointsToFlowInsensitive>();
+        tm.stop();
+    } else if (strcmp(pts, "inv") == 0) {
+        tm.start();
+        PTA->run<analysis::pta::PointsToWithInvalidate>();
         tm.stop();
     } else {
         llvm::errs() << "Unknown points to analysis, try: fs, fi\n";

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -42,6 +42,7 @@
 #include "llvm/analysis/PointsTo/PointsTo.h"
 #include "analysis/PointsTo/PointsToFlowInsensitive.h"
 #include "analysis/PointsTo/PointsToFlowSensitive.h"
+#include "analysis/PointsTo/PointsToWithInvalidate.h"
 #include "analysis/PointsTo/Pointer.h"
 
 #include "TimeMeasure.h"
@@ -55,6 +56,7 @@ static bool verbose;
 enum PTType {
     FLOW_SENSITIVE = 1,
     FLOW_INSENSITIVE,
+    WITH_INVALIDATE,
 };
 
 static std::string
@@ -364,6 +366,8 @@ int main(int argc, char *argv[])
         if (strcmp(argv[i], "-pta") == 0) {
             if (strcmp(argv[i+1], "fs") == 0)
                 type = FLOW_SENSITIVE;
+            else if (strcmp(argv[i+1], "inv") == 0)
+                type = WITH_INVALIDATE;
         } else if (strcmp(argv[i], "-pta-field-sensitive") == 0) {
             field_senitivity = (uint64_t) atoll(argv[i + 1]);
         } else if (strcmp(argv[i], "-dot") == 0) {
@@ -406,6 +410,10 @@ int main(int argc, char *argv[])
     if (type == FLOW_INSENSITIVE) {
         PA = std::unique_ptr<PointerAnalysis>(
             PTA.createPTA<analysis::pta::PointsToFlowInsensitive>()
+            );
+    } else if (type == WITH_INVALIDATE) {
+        PA = std::unique_ptr<PointerAnalysis>(
+            PTA.createPTA<analysis::pta::PointsToWithInvalidate>()
             );
     } else {
         PA = std::unique_ptr<PointerAnalysis>(

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -284,7 +284,7 @@ dumpPointerSubgraphdot(LLVMPointerAnalysis *pta, PTType type)
         printf("\tNODE%p [label=\"", node);
         printName(node, true);
         printf("\\n--- parent ---\\n");
-        printf("%p \n", node->getParent());
+        printf("%p \\n", node->getParent());
 
         if (node->getSize() || node->isHeap() || node->isZeroInitialized())
             printf("\\n[size: %lu, heap: %u, zeroed: %u]",

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -275,15 +275,16 @@ dumpPSNode(PSNode *n, PTType type)
 static void
 dumpPointerSubgraphdot(LLVMPointerAnalysis *pta, PTType type)
 {
-    std::set<PSNode *> nodes;
-    pta->getNodes(nodes);
 
     printf("digraph \"Pointer State Subgraph\" {\n");
 
     /* dump nodes */
+    const auto& nodes = pta->getNodes();
     for (PSNode *node : nodes) {
         printf("\tNODE%p [label=\"", node);
         printName(node, true);
+        printf("\\n--- parent ---\\n");
+        printf("%p \n", node->getParent());
 
         if (node->getSize() || node->isHeap() || node->isZeroInitialized())
             printf("\\n[size: %lu, heap: %u, zeroed: %u]",
@@ -342,9 +343,7 @@ dumpPointerSubgraph(LLVMPointerAnalysis *pta, PTType type, bool todot)
     if (todot)
         dumpPointerSubgraphdot(pta, type);
     else {
-        std::set<PSNode *> nodes;
-        pta->getNodes(nodes);
-
+        const auto& nodes = pta->getNodes();
         for (PSNode *node : nodes) {
             dumpPSNode(node, type);
         }

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -97,7 +97,8 @@ void printPSNodeType(enum PSNodeType type)
         ELEM(PSNodeType::MEMCPY)
         ELEM(PSNodeType::NULL_ADDR)
         ELEM(PSNodeType::UNKNOWN_MEM)
-        ELEM(PSNodeType::INVALIDATE)
+        ELEM(PSNodeType::FREE)
+        ELEM(PSNodeType::INVALIDATED)
         default:
             printf("unknown PointerSubgraph type");
     };
@@ -113,9 +114,9 @@ printName(PSNode *node, bool dot)
         name = "null";
     } else if (node->isUnknownMemory()) {
         name = "unknown";
-    } else if (node->isInvalidate() && 
+    } else if (node->isInvalidated() && 
         !node->getUserData<llvm::Value>()) {
-            name = "invalidate";
+            name = "invalidated";
     }
 
     if (!name) {

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -100,6 +100,7 @@ void printPSNodeType(enum PSNodeType type)
         ELEM(PSNodeType::NULL_ADDR)
         ELEM(PSNodeType::UNKNOWN_MEM)
         ELEM(PSNodeType::FREE)
+        ELEM(PSNodeType::INVALIDATE_LOCALS)
         ELEM(PSNodeType::INVALIDATED)
         default:
             printf("unknown PointerSubgraph type");

--- a/tools/llvm-ps-dump.cpp
+++ b/tools/llvm-ps-dump.cpp
@@ -97,6 +97,7 @@ void printPSNodeType(enum PSNodeType type)
         ELEM(PSNodeType::MEMCPY)
         ELEM(PSNodeType::NULL_ADDR)
         ELEM(PSNodeType::UNKNOWN_MEM)
+        ELEM(PSNodeType::INVALIDATE)
         default:
             printf("unknown PointerSubgraph type");
     };
@@ -112,6 +113,9 @@ printName(PSNode *node, bool dot)
         name = "null";
     } else if (node->isUnknownMemory()) {
         name = "unknown";
+    } else if (node->isInvalidate() && 
+        !node->getUserData<llvm::Value>()) {
+            name = "invalidate";
     }
 
     if (!name) {

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -71,6 +71,7 @@
 
 #include "analysis/PointsTo/PointsToFlowInsensitive.h"
 #include "analysis/PointsTo/PointsToFlowSensitive.h"
+#include "analysis/PointsTo/PointsToWithInvalidate.h"
 #include "analysis/PointsTo/Pointer.h"
 
 using namespace dg;
@@ -96,7 +97,7 @@ enum {
 };
 
 enum PtaType {
-    fs, fi
+    fs, fi, inv
 };
 
 llvm::cl::OptionCategory SlicingOpts("Slicer options", "");
@@ -138,7 +139,8 @@ llvm::cl::opt<PtaType> pta("pta",
     llvm::cl::desc("Choose pointer analysis to use:"),
     llvm::cl::values(
         clEnumVal(fi, "Flow-insensitive PTA (default)"),
-        clEnumVal(fs, "Flow-sensitive PTA")
+        clEnumVal(fs, "Flow-sensitive PTA"),
+        clEnumVal(inv, "PTA with invalidate nodes")
 #if LLVM_VERSION_MAJOR < 4
         , nullptr
 #endif
@@ -364,6 +366,8 @@ public:
                 os << "flow-insensitive\n";
             else if (pta == fs)
                 os << "flow-sensitive\n";
+            else if (pta == inv)
+                os << "flow-sensitive with invalidate\n";
 
             os << ";   * PTA field sensitivity: " << pta_field_sensitivie << "\n";
 
@@ -651,6 +655,8 @@ public:
             PTA->run<analysis::pta::PointsToFlowSensitive>();
         else if (pta == PtaType::fi)
             PTA->run<analysis::pta::PointsToFlowInsensitive>();
+        else if (pta == PtaType::inv)
+            PTA->run<analysis::pta::PointsToWithInvalidate>();
         else
             assert(0 && "Wrong pointer analysis");
 


### PR DESCRIPTION
New pointer analysis was added because we need to work with new types of nodes that are used to tag some memory as invalidated (eg. after calling free or after returning from a function). We can now therefore distinguish pointers that can point to invalidated memory.