### PR TITLE
load node has unknown pointer info

### DIFF
--- a/src/analysis/PointsTo/PointerAnalysis.cpp
+++ b/src/analysis/PointsTo/PointerAnalysis.cpp
@@ -53,6 +53,11 @@ bool PointerAnalysis::processLoad(PSNode *node)
         if (ptr.isNull())
             continue;
 
+        if (ptr.isUnknown()) {
+            changed |= node->addPointsTo(UNKNOWN_MEMORY, UNKNOWN_OFFSET);
+            continue;
+        }
+        
         // find memory objects holding relevant points-to
         // information
         std::vector<MemoryObject *> objects;


### PR DESCRIPTION
Hi. unknown pointer info lacks after load with struct member access through unknown point-to. 
I don't know what status of the pointer is correct.

struct tag { int *p; };
struct tag *f();
main()
{
struct tag *s = f();
s->p; // s->p should be unknown.
}