### PR TITLE
travis: testing with LLVM 3.8 and 5.0, debug build, testing both PTA=FS and PTA=FI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,59 +11,24 @@ addons:
     sources:
       # newer gcc and clang
       - ubuntu-toolchain-r-test
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
       - libz-dev
 
-matrix:
-  include:
-    # compile with g++4, use LLVM 4
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-          packages:
-            - g++
-      env:
-        - MATRIX_EVAL="CC=gcc && CXX=g++"
-        - LLVM_VERSION=4.0
+env:
+    - LLVM=4.0
 
-    # compile with g++5, use LLVM 4
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-        - LLVM_VERSION=4.0
+compiler:
+    - 'clang++'
+    - 'g++'
+    - 'g++-5'
 
-    # compile with clang 4, use LLVM 4
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-          packages:
-            - clang-4.0
-      env:
-        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-        - LLVM_VERSION=4.0
-
-before_install:
-    - eval "${MATRIX_EVAL}"
 install:
   - git clone --depth 1 https://github.com/tomsik68/travis-llvm.git
   - cd travis-llvm
   - chmod +x travis-llvm.sh
-  - ./travis-llvm.sh ${LLVM_VERSION}
+  - ./travis-llvm.sh ${LLVM}
   - cd ..
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - cd ..
 
 script:
-  - cmake .
+  - cmake -DCMAKE_BUILD_TYPE=DEBUG .
   - make -j2
   - cd tests
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,14 @@ addons:
       - ubuntu-toolchain-r-test
       - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
         key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
     packages:
       - libz-dev
 
 env:
+    - LLVM=3.8
     - LLVM=4.0
+    - LLVM=5.0
 
 compiler:
     - 'clang++'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,12 @@ addons:
       - libz-dev
 
 env:
-    - LLVM=3.8
-    - LLVM=4.0
-    - LLVM=5.0
+    - LLVM=3.8 PTA=fs
+    - LLVM=3.8 PTA=fi
+    - LLVM=4.0 PTA=fs
+    - LLVM=4.0 PTA=fi
+    - LLVM=5.0 PTA=fs
+    - LLVM=5.0 PTA=fi
 
 compiler:
     - 'clang++'
@@ -39,7 +42,7 @@ script:
   - make -j2
   - cd tests
   - make
-  - make test
+  - DG_TESTS_PTA="$PTA" make test
 
 notifications:
     email: false

--- a/tests/slicing-interprocedural8.sh
+++ b/tests/slicing-interprocedural8.sh
@@ -15,6 +15,9 @@ LINKEDFILE="$NAME.sliced.linked"
 compile "$CODE" "$BCFILE"
 
 # slice the code
+if [ ! -z "$DG_TESTS_PTA" ]; then
+    export DG_TESTS_PTA="-pta $DG_TESTS_PTA"
+fi
 llvm-slicer $DG_TESTS_PTA -c test_assert "$BCFILE"
 
 # link assert to the code


### PR DESCRIPTION
I've beautified the .travis.yml and extended it to perform more tests. [Here are travis build results for this branch](https://travis-ci.org/tomsik68/dg/builds/335143789).

The new .travis.yml runs tests with both `PTA=fs` and `PTA=fi` with LLVM versions 3.8, 4.0 and 5.0 and g++-4, g++-5 and clang++ (version matching LLVM). All this together produces 18 testing configurations.

It also uses debug build, which fixes issue #164.

I also had to fix handling of environment variable `DG_TESTS_PTA` in `slicing-interprocedural8.sh`. The problem was, that this single test treated the variable differently than `test-runner.sh` used by other tests. It expected the value to be e.g. `-pta fs`, while `test-runner.sh` expected it to be just `fs`.