### PR TITLE
fix linking with LLVM libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,15 +63,6 @@ if (LLVM_DG)
 	endif(LLVM_BUILD_PATH)
 
 	add_definitions(${LLVM_DEFINITIONS})
-
-	if (NOT ${LLVM_PACKAGE_VERSION} VERSION_LESS "3.5")
-		llvm_map_components_to_libnames(llvm_libs support core
-		                                irreader bitwriter analysis)
-	else()
-		llvm_map_components_to_libraries(llvm_libs support core
-		                                 irreader bitwriter analysis)
-	endif()
-
 	add_definitions(-DHAVE_LLVM)
 endif(LLVM_DG)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,17 +32,6 @@ add_library(LLVMpta SHARED
 
 target_link_libraries(LLVMpta PUBLIC PTA)
 
-# We need all the symbols with dynamic libs. With static libs, we get errors.
-if (BUILD_SHARED_LIBS)
-	if (${LLVM_PACKAGE_VERSION} VERSION_GREATER "3.4")
-		llvm_map_components_to_libnames(LP_llvm_libs core support)
-	else()
-		llvm_map_components_to_libraries(LP_llvm_libs core support)
-	endif()
-
-	target_link_libraries(LLVMpta PUBLIC ${LP_llvm_libs})
-endif()
-
 add_library(LLVMdg SHARED
 	BBlock.h
 	Node.h

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,13 @@
 if (LLVM_DG)
-	set(LLVM_LINK_COMPONENTS core engine asmparser bitreader support)
+if (${LLVM_PACKAGE_VERSION} VERSION_GREATER "3.4")
+	llvm_map_components_to_libnames(llvm_irreader irreader)
+	llvm_map_components_to_libnames(llvm_bitwriter bitwriter)
+	llvm_map_components_to_libnames(llvm_analysis analysis)
+else()
+	llvm_map_components_to_libraries(llvm_irreader irreader)
+	llvm_map_components_to_libraries(llvm_bitwriter bitwriter)
+	llvm_map_components_to_libraries(llvm_analysis analysis)
+endif()
 
 	# generate a git-version.h with a HEAD commit hash tag
 	# (if it changed)
@@ -9,23 +17,39 @@ if (LLVM_DG)
 	include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 	add_executable(llvm-dg-dump llvm-dg-dump.cpp)
-	target_link_libraries(llvm-dg-dump LLVMdg)
+	target_link_libraries(llvm-dg-dump PRIVATE LLVMdg)
+	target_link_libraries(llvm-dg-dump
+				PRIVATE ${llvm_irreader}
+				PRIVATE ${llvm_bitwriter})
 
 	add_executable(llvm-slicer llvm-slicer.cpp)
-	target_link_libraries(llvm-slicer LLVMdg)
+	target_link_libraries(llvm-slicer PRIVATE LLVMdg)
+	target_link_libraries(llvm-slicer
+				PRIVATE ${llvm_irreader}
+				PRIVATE ${llvm_bitwriter}
+				PRIVATE ${llvm_analysis})
 	add_dependencies(llvm-slicer gitversion)
 
 	add_executable(llvm-ps-dump llvm-ps-dump.cpp)
-	target_link_libraries(llvm-ps-dump LLVMdg)
+	target_link_libraries(llvm-ps-dump PRIVATE LLVMdg)
+	target_link_libraries(llvm-ps-dump
+				PRIVATE ${llvm_irreader}
+				PRIVATE ${llvm_analysis})
 
 	add_executable(llvm-pta-compare llvm-pta-compare.cpp)
-	target_link_libraries(llvm-pta-compare LLVMdg)
+	target_link_libraries(llvm-pta-compare PRIVATE LLVMdg)
+	target_link_libraries(llvm-pta-compare
+				PRIVATE ${llvm_irreader}
+				PRIVATE ${llvm_analysis})
 
 	add_executable(llvm-rd-dump llvm-rd-dump.cpp)
-	target_link_libraries(llvm-rd-dump LLVMdg)
+	target_link_libraries(llvm-rd-dump PRIVATE LLVMdg)
+	target_link_libraries(llvm-rd-dump
+				PRIVATE ${llvm_irreader}
+				PRIVATE ${llvm_analysis})
 
 	add_executable(llvm-to-source llvm-to-source.cpp)
-	target_link_libraries(llvm-to-source PRIVATE ${llvm_libs})
+	target_link_libraries(llvm-to-source PRIVATE ${llvm_irreader})
 
 	install(TARGETS llvm-dg-dump llvm-slicer
 		RUNTIME DESTINATION bin)


### PR DESCRIPTION
Make only tools (binaries) to link with LLVM libraries,
the shared objects do not need that (they will use the
LLVM libraries linked to the binaries)

Signed-off-by: Marek Chalupa <xchalup4@fi.muni.cz>