### PR TITLE
fix strong kill & intervals handling

### DIFF
--- a/src/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
+++ b/src/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
@@ -49,10 +49,10 @@ std::vector<MarkerSRGBuilderFS::NodeT *> MarkerSRGBuilderFS::readVariable(const 
 
 void MarkerSRGBuilderFS::addPhiOperands(const DefSite& v, NodeT *phi, BlockT *block, BlockT *start, const std::vector<detail::Interval>& covered) {
 
-    if (var.len == 0 || var.offset.isUnknown()) {
-        var.len = Offset::UNKNOWN;
-        var.offset = 0;
-    }
+    DefSite var = v;
+    const auto interval = concretize(detail::Interval{var.offset, var.len});
+    var.offset = interval.getStart();
+    var.len = interval.getLength();
     phi->addDef(var, true);
     phi->addUse(var);
 

--- a/src/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.h
+++ b/src/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.h
@@ -77,7 +77,7 @@ class MarkerSRGBuilderFS : public SparseRDGraphBuilder
                 if (node->isOverwritten(def) && !def.offset.isUnknown()) {
                     detail::Interval interval = concretize(detail::Interval{def.offset, def.len}, def.target->getSize());
                     last_def[def.target][block].killOverlapping(interval);
-                    //last_weak_def[def.target][block].killOverlapping(interval);
+                    last_weak_def[def.target][block].killOverlapping(interval);
                     last_def[def.target][block].add(std::move(interval), node);
                 } else {
                     last_weak_def[def.target][block].add(concretize(detail::Interval{def.offset, def.len}, def.target->getSize()), node);

--- a/src/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
+++ b/src/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
@@ -395,7 +395,11 @@ RDNode *LLVMRDBuilderSemisparse::createLoad(const llvm::Instruction *Inst, RDBlo
     addNode(Inst, node);
     rb->append(node);
 
-    node->addUses(getPointsTo(LI->getPointerOperand(), rb));
+    std::vector<DefSite> uses = getPointsTo(LI->getPointerOperand(), rb);
+    for (auto& ds : uses) {
+        ds.len = getAllocatedSize(LI->getPointerOperand()->getType()->getPointerElementType(), DL);
+    }
+    node->addUses(uses);
 
     return node;
 }

--- a/src/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
+++ b/src/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
@@ -398,6 +398,10 @@ RDNode *LLVMRDBuilderSemisparse::createLoad(const llvm::Instruction *Inst, RDBlo
     std::vector<DefSite> uses = getPointsTo(LI->getPointerOperand(), rb);
     for (auto& ds : uses) {
         ds.len = getAllocatedSize(LI->getPointerOperand()->getType()->getPointerElementType(), DL);
+        if (ds.offset.isUnknown() || ds.len == 0) {
+            ds.len = Offset::UNKNOWN;
+            ds.offset = 0;
+        }
     }
     node->addUses(uses);
 
@@ -412,9 +416,18 @@ RDNode *LLVMRDBuilderSemisparse::createStore(const llvm::Instruction *Inst, RDBl
 
     auto pts = getPointsTo(Inst->getOperand(1), rb);
     for (auto& ds : pts) {
-        bool strong = isStrongUpdate(Inst->getOperand(1), ds, rb);
-        if (!ds.offset.isUnknown())
+        bool strong = false;
+        if (!ds.offset.isUnknown() && ds.len != 0) {
             ds.len = getAllocatedSize(Inst->getOperand(0)->getType(), DL);
+            strong = isStrongUpdate(Inst->getOperand(1), ds, rb);
+        } else {
+            ds.offset = 0;
+            ds.len = Offset::UNKNOWN;
+        }
+        if (ds.len == 0) {
+            ds.offset = 0;
+            ds.len = Offset::UNKNOWN;
+        }
         node->addDef(ds, strong);
     }
 


### PR DESCRIPTION
I have managed to fix that bug I had for such a long time. The problem occurred in programs where basic 2 basic blocks with strong updates of the same variable joined to a block with use of that variable. Rather than preserving both strong updates, one of them was mistakenly killed.

Another bug that popped up after fixing the above-mentioned one was about handling intervals. When some part of an interval of a variable is killed, the rest of the interval that is not supposed to be killed was lost, too. This should not be happening anymore.

This PR fixes both of the issues.