### PR TITLE
PTA: fix strong updates for store

### DIFF
--- a/src/analysis/PointsTo/PointerAnalysis.h
+++ b/src/analysis/PointsTo/PointerAnalysis.h
@@ -57,10 +57,8 @@ public:
         assert(PS && "Need valid PointerSubgraph object");
 
         // compute the strongly connected components
-        if (prepro_geps) {
-            SCC<PSNode> scc_comp;
-            SCCs = std::move(scc_comp.compute(PS->getRoot()));
-        }
+        SCC<PSNode> scc_comp;
+        SCCs = std::move(scc_comp.compute(PS->getRoot()));
     }
 
     virtual ~PointerAnalysis() {}
@@ -92,6 +90,8 @@ public:
     }
 
     PointerSubgraph *getPS() const { return PS; }
+
+    const std::vector<std::vector<PSNode *> > &getSCCs() const { return SCCs; }
 
     virtual void enqueue(PSNode *n)
     {


### PR DESCRIPTION
Do not make strong update for store instructions if
the memory was allocated on loop. It would lead to
incorrect behaviour.