### PR TITLE
Fix invalid memory access in semi-sparse RDA

### DIFF
--- a/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
+++ b/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
@@ -115,7 +115,7 @@ MarkerSRGBuilderFS::NodeT* MarkerSRGBuilderFS::tryRemoveTrivialPhi(NodeT *phi) {
         return phi;
     }
 
-    auto& users = users_it->second;
+    auto users = users_it->second;
     for (auto& edge : users) {
         NodeT* user = edge.second;
         if (user != phi && user->getType() == RDNodeType::PHI) {

--- a/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
+++ b/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.cpp
@@ -145,7 +145,7 @@ void MarkerSRGBuilderFS::replacePhi(NodeT *phi, NodeT *replacement) {
         }
     }
 
-    auto& uses = uses_it->second;
+    auto uses = uses_it->second;
 
     for (auto& use_edge : uses) {
         DefSite var = use_edge.first;

--- a/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.h
+++ b/lib/analysis/ReachingDefinitions/Srg/MarkerSRGBuilderFS.h
@@ -110,13 +110,13 @@ class MarkerSRGBuilderFS : public SparseRDGraphBuilder
     }
 
     void removeSrgEdge(NodeT *from, NodeT *to, const DefSite& var) {
-        auto to_vec = srg[to];
+        auto& to_vec = srg[to];
         auto it = std::find(to_vec.begin(), to_vec.end(), std::make_pair(var, from));
         if (it != to_vec.end()) {
             to_vec.erase(it);
         }
 
-        auto from_vec = reverse_srg[from];
+        auto& from_vec = reverse_srg[from];
         auto reverse_it = std::find(from_vec.begin(), from_vec.end(), std::make_pair(var, to));
         if (reverse_it != from_vec.end()) {
             from_vec.erase(reverse_it);


### PR DESCRIPTION
Hi, this PR should fix segmentation fault errors in semi-sparse RDA that appeared in global5 and global6 tests.