### PR TITLE
PTA: Recompute SCCs because of function pointers

### DIFF
--- a/include/dg/analysis/PointsTo/PointerAnalysis.h
+++ b/include/dg/analysis/PointsTo/PointerAnalysis.h
@@ -27,6 +27,7 @@ class PointerAnalysis
 
     // strongly connected components of the PointerSubgraph
     std::vector<std::vector<PSNode *> > SCCs;
+    unsigned sccs_index{0};
 
     void initPointerAnalysis() {
         assert(PS && "Need PointerSubgraph object");
@@ -34,6 +35,7 @@ class PointerAnalysis
         // compute the strongly connected components
         SCC<PSNode> scc_comp;
         SCCs = std::move(scc_comp.compute(PS->getRoot()));
+        sccs_index = scc_comp.getIndex();
     }
 
 protected:
@@ -237,6 +239,13 @@ private:
                        std::vector<MemoryObject *>& destObjects,
                        const Pointer& sptr, const Pointer& dptr,
                        Offset len);
+
+    void recomputeSCCs()
+    {
+        SCC<PSNode> scc_comp(sccs_index);
+        SCCs = std::move(scc_comp.compute(PS->getRoot()));
+        sccs_index = scc_comp.getIndex();
+    }
 };
 
 } // namespace pta

--- a/include/dg/analysis/PointsTo/PointerAnalysisFS.h
+++ b/include/dg/analysis/PointsTo/PointerAnalysisFS.h
@@ -190,12 +190,7 @@ protected:
         return mm;
     }
 
-private:
-    static bool needsMerge(PSNode *n) {
-        return n->predecessorsNum() > 1 || canChangeMM(n);
-    }
-
-    bool isInLoop(PSNode *n) const {
+    bool isOnLoop(PSNode *n) const {
         unsigned idx = n->getSCCId();
         const auto& scc = getSCCs()[idx];
 
@@ -205,10 +200,19 @@ private:
 
     bool pointsToAllocationInLoop(PSNode *n) {
         for (const auto& ptr : n->pointsTo) {
-            if (isInLoop(ptr.target))
+            // skip invalidated, null and unknown memory
+            if (!ptr.isValid() || ptr.isInvalidated())
+                continue;
+
+            if (isOnLoop(ptr.target))
                 return true;
         }
         return false;
+    }
+
+private:
+    static bool needsMerge(PSNode *n) {
+        return n->predecessorsNum() > 1 || canChangeMM(n);
     }
 
     // keep all the maps in order to free the memory

--- a/include/dg/analysis/SCC.h
+++ b/include/dg/analysis/SCC.h
@@ -19,14 +19,13 @@ public:
     using SCC_component_t = std::vector<NodeT *>;
     using SCC_t = std::vector<SCC_component_t>;
 
-    SCC<NodeT>() : index(0) {}
+    SCC<NodeT>(unsigned not_visit = 0)
+    : index(not_visit), NOT_VISITED(not_visit) {}
 
     // returns a vector of vectors - every inner vector
     // contains the nodes that for a SCC
     SCC_t& compute(NodeT *start)
     {
-        assert(start->dfs_id == 0);
-
         _compute(start);
         assert(stack.empty());
 
@@ -44,13 +43,21 @@ public:
         return scc[idx];
     }
 
+    unsigned getIndex() const { return index; }
 
 private:
     ADT::QueueLIFO<NodeT *> stack;
     unsigned index;
+    // it the dfsid is less or equal to this value,
+    // then it is considered not to be visited.
+    // it is due to the repeated execution of this algorithm
+    // on the same nodes
+    const unsigned NOT_VISITED;
 
     // container for the strongly connected components.
     SCC_t scc;
+
+    bool not_visited(NodeT *n) { return n->dfs_id <= NOT_VISITED; }
 
     void _compute(NodeT *n)
     {
@@ -62,7 +69,7 @@ private:
         n->on_stack = true;
 
         for (NodeT *succ : n->getSuccessors()) {
-            if (succ->dfs_id == 0) {
+            if (not_visited(succ)) {
                 assert(!succ->on_stack);
                 _compute(succ);
                 n->lowpt = std::min(n->lowpt, succ->lowpt);

--- a/lib/analysis/PointsTo/PointerAnalysis.cpp
+++ b/lib/analysis/PointsTo/PointerAnalysis.cpp
@@ -382,7 +382,8 @@ bool PointerAnalysis::processNode(PSNode *node)
                     changed = true;
 
                     if (ptr.isValid() && !ptr.isInvalidated()) {
-                        functionPointerCall(node, ptr.target);
+                        if (functionPointerCall(node, ptr.target))
+                            recomputeSCCs();
                     } else {
                         error(node, "Calling invalid pointer as a function!");
                         continue;


### PR DESCRIPTION
When a new subgraph is created because of function pointers, we need to recompute SCCs.