### PR TITLE
Improvements of DisjunctiveIntervalMap & BasicRDMap

### DIFF
--- a/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
+++ b/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
@@ -1,6 +1,11 @@
 #ifndef _DG_DISJUNCTIVE_INTERVAL_MAP_H_
 #define _DG_DISJUNCTIVE_INTERVAL_MAP_H_
 
+#include "dg/analysis/Offset.h"
+#include <cassert>
+#include <map>
+#include <set>
+
 namespace dg {
 namespace analysis {
 namespace rd {

--- a/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
+++ b/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
@@ -88,6 +88,10 @@ public:
     // return true if the map has an entry for
     // each single byte from the interval I
     bool overlapsFull(const IntervalT& I) const {
+        if (_mapping.empty()) {
+            return false;
+        }
+
         auto ge = _find_ge(I);
         if (ge == _mapping.end()) {
             auto last = _get_last();

--- a/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
+++ b/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h
@@ -133,6 +133,23 @@ public:
     typename MappingT::iterator end() { return _mapping.end(); }
     typename MappingT::const_iterator end() const { return _mapping.end(); }
 
+#ifndef NDEBUG
+    friend std::ostream& operator<<(std::ostream& os, const DisjunctiveIntervalMap<ValueT, IntervalValueT>& map) {
+        os << "{";
+        for (const auto& pair : map) {
+            if (pair.second.empty())
+                continue;
+
+            os << "{ ";
+            os << pair.first.start << "-" << pair.first.end;
+            os << ": " << *pair.second.begin();
+            os << " }, ";
+        }
+        os << "}";
+        return os;
+    }
+#endif
+
 private:
 
     // Split interval [a,b] to two intervals [a, where] and [where + 1, b].

--- a/include/dg/analysis/ReachingDefinitions/RDMap.h
+++ b/include/dg/analysis/ReachingDefinitions/RDMap.h
@@ -192,9 +192,13 @@ public:
         friend class BasicRDMap;
 
         public:
-        const std::pair<const DefSite&, const RDNodesSet&> operator*() const {
-            return std::make_pair(it->first, it->second);
-        };
+        auto operator*() -> decltype(*it) {
+            return *it;
+        }
+
+        const auto operator*() const -> decltype(*it) {
+            return *it;
+        }
 
         _map_iterator& operator++() { ++it; return *this; }
         _map_iterator operator++(int) { auto tmp = *this; ++it; return tmp; }

--- a/include/dg/analysis/ReachingDefinitions/RDMap.h
+++ b/include/dg/analysis/ReachingDefinitions/RDMap.h
@@ -196,7 +196,7 @@ public:
             return *it;
         }
 
-        const auto operator*() const -> decltype(*it) {
+        auto operator*() const -> decltype(*it) {
             return *it;
         }
 

--- a/tests/disjunctive-intervals-map-test.cpp
+++ b/tests/disjunctive-intervals-map-test.cpp
@@ -396,3 +396,30 @@ TEST_CASE("OverlapsEmptyNonemptyinterval", "DisjunctiveIntervalMap") {
     REQUIRE_FALSE(M.overlapsFull(0, 10));
     REQUIRE_FALSE(M.overlapsFull(10, 10));
 }
+
+TEST_CASE("Split", "DisjunctiveIntervalMap") {
+    DisjunctiveIntervalMap<int, int> M;
+
+    // add 0-4
+    M.update(0,4, 1);
+
+    // now add intervals such that their union is 0-4
+    M.update(0,1, 2);
+    M.update(1,2, 3);
+    M.update(2,3, 4);
+    M.update(3,4, 5);
+
+    /*
+     * The map should now contain:
+     * [0,0] -> 2
+     * [1,1] -> 3
+     * [2,2] -> 4
+     * [3,4] -> 5
+     */
+    REQUIRE_THAT(M, HasStructure({
+        {0,0, 2},
+        {1,1, 3},
+        {2,2, 4},
+        {3,4, 5}
+    }));
+}

--- a/tests/disjunctive-intervals-map-test.cpp
+++ b/tests/disjunctive-intervals-map-test.cpp
@@ -13,6 +13,20 @@
 using namespace dg::analysis::rd;
 using dg::analysis::Offset;
 
+static std::ostream& operator<<(std::ostream& os, const std::vector<std::tuple<int,int,int>>& v) {
+    os << "{";
+    for (const auto& tup : v) {
+        os << "{ ";
+        os << std::get<0>(tup) << "-";
+        os << std::get<1>(tup) << ": ";
+        os << std::get<2>(tup);
+        os << " }, ";
+    }
+    os << "}";
+    return os;
+}
+
+
 template<typename ValueT, typename IntervalValueT>
 class DisjunctiveIntervalMapMatcher : public Catch::MatcherBase<DisjunctiveIntervalMap<ValueT, IntervalValueT>> {
     std::vector<std::tuple<IntervalValueT, IntervalValueT, ValueT>> structure;
@@ -52,19 +66,6 @@ public:
         return ss.str();
     }
 };
-
-static std::ostream& operator<<(std::ostream& os, const std::vector<std::tuple<int,int,int>>& v) {
-    os << "{";
-    for (const auto& tup : v) {
-        os << "{ ";
-        os << std::get<0>(tup) << "-";
-        os << std::get<1>(tup) << ": ";
-        os << std::get<2>(tup);
-        os << " }, ";
-    }
-    os << "}";
-    return os;
-}
 
 static inline DisjunctiveIntervalMapMatcher<int, int> HasStructure(std::initializer_list<std::tuple<int, int, int>> structure) {
     return DisjunctiveIntervalMapMatcher<int, int>(structure);

--- a/tests/disjunctive-intervals-map-test.cpp
+++ b/tests/disjunctive-intervals-map-test.cpp
@@ -332,3 +332,9 @@ TEST_CASE("OverlappsRandom", "DisjunctiveIntervalMap") {
         }
     }
 }
+
+TEST_CASE("OverlapsEmptyNonemptyinterval", "DisjunctiveIntervalMap") {
+    DisjunctiveIntervalMap<int, int> M;
+    REQUIRE_FALSE(M.overlapsFull(0, 10));
+    REQUIRE_FALSE(M.overlapsFull(10, 10));
+}

--- a/tests/disjunctive-intervals-map-test.cpp
+++ b/tests/disjunctive-intervals-map-test.cpp
@@ -417,9 +417,9 @@ TEST_CASE("Split", "DisjunctiveIntervalMap") {
      * [3,4] -> 5
      */
     REQUIRE_THAT(M, HasStructure({
-        {0,0, 2},
-        {1,1, 3},
-        {2,2, 4},
-        {3,4, 5}
+        std::make_tuple(0,0, 2),
+        std::make_tuple(1,1, 3),
+        std::make_tuple(2,2, 4),
+        std::make_tuple(3,4, 5)
     }));
 }


### PR DESCRIPTION
Hi, I've been trying to integrate the DisjunctiveIntervalMap with semi-sparse RDA and encountered some issues along the way, so I decided to patch some of them myself. 

The following issues are fixed in this PR:
- missing includes
- it is impossible to iterate through `BasicRDMap` for some reason (`llvm-rd-dump` doesn't work either)
- behavior of `overlapsFull` when called on an empty map

There is still one more issue I don't really know how to fix, so I add a failing unit test at least. Briefly, when you add an interval `0-4` and then gradually add intervals `0-1`, `1-2`, `2-3` and `3-4`, the test terminates with the following message: `disjunctive-intervals-map-test: /home/xjasek/formela/dg/include/dg/analysis/ReachingDefinitions/DisjunctiveIntervalMap.h:335: void dg::analysis::rd::DisjunctiveIntervalMap<ValueT, IntervalValueT>::_check() const [with ValueT = int; IntervalValueT = int]: Assertion 'last.end < it->first.start' failed.`

Also, I used `rdmap-refactor` branch because I need `overlapsFull` method.