### PR TITLE
PointsTo: fix creating returns

### DIFF
--- a/lib/llvm/analysis/PointsTo/Instructions.cpp
+++ b/lib/llvm/analysis/PointsTo/Instructions.cpp
@@ -330,7 +330,8 @@ PSNode *LLVMPointerSubgraphBuilder::createReturn(const llvm::Instruction *Inst)
             op1 = NULLPTR;
         else if (typeCanBePointer(DL, retVal->getType()) &&
                   (!isInvalid(retVal->stripPointerCasts(), invalidate_nodes) ||
-                   llvm::isa<llvm::ConstantExpr>(retVal)))
+                   llvm::isa<llvm::ConstantExpr>(retVal) ||
+                   llvm::isa<llvm::UndefValue>(retVal)))
             op1 = getOperand(retVal);
     }
 


### PR DESCRIPTION
Get operand of a return instruction even if the return value is undef.