### PR TITLE
Fix LLVMRDBuilderSemisparse to remember only return nodes

### DIFF
--- a/lib/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
+++ b/lib/llvm/analysis/ReachingDefinitions/LLVMRDBuilderSemisparse.cpp
@@ -711,7 +711,7 @@ LLVMRDBuilderSemisparse::buildFunction(const llvm::Function& F)
         size_t succ_num = blockAddSuccessors(built_blocks, last_subblock, block);
         // if we have not added any successor, then the last node
         // of this block is a return node
-        if (succ_num == 0)
+        if (succ_num == 0 && last_subblock->getLastNode()->getType() == RDNodeType::RETURN)
             rets.push_back(last_subblock->getLastNode());
         last_llvm_block = &block;
     }


### PR DESCRIPTION
After the last block of function is built, its successors need to be added. However, if the block has no successors and doesn't end with return, it should have no successors. This PR fixes the issue in semi-sparse RDA. The issue is not present with dense RDA. 

This is also one of the reasons why slicing using semi-sparse RDA sometimes produces bigger program than slicing using RDA.