### PR TITLE
Fix the element offset while initializing the global structure

### DIFF
--- a/lib/llvm/analysis/PointsTo/Globals.cpp
+++ b/lib/llvm/analysis/PointsTo/Globals.cpp
@@ -50,7 +50,18 @@ LLVMPointerGraphBuilder::handleGlobalVariableInitializer(const llvm::Constant *C
     // if the global is zero initialized, just set the zeroInitialized flag
     if (C->isNullValue()) {
         node->setZeroInitialized();
-    } else if (C->getType()->isAggregateType()) {
+    } else if (C->getType()->isStructTy()) {
+        uint64_t off = 0;
+        auto STy = cast<StructType>(C->getType());
+        const StructLayout *SL = M->getDataLayout().getStructLayout(STy);
+        int i = 0;
+        for (auto I = C->op_begin(), E = C->op_end(); I != E; ++I, ++i) {
+            const Constant *op = cast<Constant>(*I);
+            // recursively dive into the aggregate type
+            off = SL->getElementOffset(i);
+            handleGlobalVariableInitializer(op, node, offset + off);
+        }
+    } else if (C->getType()->isArrayTy()) {
         uint64_t off = 0;
         for (auto I = C->op_begin(), E = C->op_end(); I != E; ++I) {
             const Constant *op = cast<Constant>(*I);


### PR DESCRIPTION
Fix issue #312.

Due to the alignment of C structure, the offset cannot be correctly inferred while initializing the global C structure, if simply using function `getTypeAllocSize` of `DataLayout`.

Since the aggregate type is either an array of a structure, I split the original if branch into two branches.