### PR TITLE
Add a spec file template + relevant fixes

### DIFF
--- a/dg.spec.rpkg
+++ b/dg.spec.rpkg
@@ -1,0 +1,87 @@
+# vim: syntax=spec
+
+Name:       {{{ git_dir_name }}}
+Version:    {{{ git_dir_version }}}
+Release:    1%{?dist}
+Summary:    Various program analyses, construction of dependence graphs and program slicing of LLVM bitcode
+
+License:    MIT
+URL:        https://github.com/mchalupa/dg
+VCS:        {{{ git_dir_vcs }}}
+
+Source:     {{{ git_dir_archive }}}
+
+BuildRequires: clang
+BuildRequires: cmake
+BuildRequires: gcc
+BuildRequires: llvm-devel
+BuildRequires: ncurses-devel
+BuildRequires: python3
+BuildRequires: zlib-devel
+
+# FIXME: dg should support dynamic linking with LLVM
+BuildRequires: llvm-static
+
+Requires: clang
+Requires: llvm
+
+%description
+DG is a library containing various bits for program analysis. However, the main
+motivation of this library is program slicing. The library contains implementation
+of a pointer analysis, data dependence analysis, control dependence analysis,
+and an analysis of relations between values in LLVM bitcode. All of the analyses
+target LLVM bitcode, but most of them are written in a generic way, so they are
+not dependent on LLVM in particular.
+
+%prep
+{{{ git_dir_setup_macro }}}
+GIT_REVISION={{{ git rev-parse --short --sq HEAD }}}
+sed -i "s/unknown/$GIT_REVISION/" tools/git-version.sh
+
+%build
+%if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
+  %cmake . -DCMAKE_BUILD_TYPE=Release
+  %make_build
+%endif
+
+%if 0%{?mageia} == 7
+  %cmake -DCMAKE_BUILD_TYPE=Release
+  %make_build
+%endif
+
+%if 0%{?mageia} > 7 || 0%{?sle_version} || 0%{?suse_version}
+  %cmake -DCMAKE_BUILD_TYPE=Release
+  %cmake_build
+%endif
+
+%install
+%if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
+  %make_install
+%endif
+
+%if 0%{?mageia} == 7
+  cd %{_cmake_builddir}
+  %make_install
+%endif
+
+%if 0%{?mageia} > 7 || 0%{?sle_version} || 0%{?suse_version}
+  %cmake_install
+%endif
+
+%check
+
+%if 0%{?mageia} == 7
+  cd %{_cmake_builddir}
+%endif
+
+%if 0%{?mageia} > 7 || 0%{?sle_version} || 0%{?suse_version}
+  cd %{__builddir}
+%endif
+
+make check %{?_smp_mflags}
+
+%files
+%license LICENSE
+%{_bindir}/*
+%{_includedir}/%{name}
+%{_libdir}/*

--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -21,10 +21,10 @@ On ArchLinux, the command for installing the dependencies is the following:
 pacman -S git cmake make llvm clang gcc python
 ```
 
-On Fedora, the command for installing the dependencies is the following:
+On CentOS/RHEL/Fedora, the command for installing the dependencies is the following:
 
 ```
-dnf install git cmake make zlib-devel llvm-devel llvm-static gcc-c++
+dnf install git cmake make zlib-devel llvm-devel llvm-static gcc-c++ ncurses-devel
 ```
 
 You can use also LLVM compiled from sources (see below).

--- a/doc/downloading.md
+++ b/doc/downloading.md
@@ -7,6 +7,8 @@ You can obtain pre-compiled DG project in several forms.
 You can download the image from [Docker Hub](https://hub.docker.com/r/mchalupa/dg). The image
 contains, apart from DG, also vim and emacs editors and clang, so you can try dg out!
 
+> **INFO**: The packages contain only the library and `llvm-slicer`. Other tools are not included.
+
 ## Ubuntu package
 
 A binary package for Ubuntu 18.04 can be found in [Releases](https://github.com/mchalupa/dg/releases/tag/v0.9-pre).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -213,7 +213,7 @@ target_link_libraries(dgllvmsdg
 
 install(TARGETS dgllvmdg dgllvmthreadregions dgllvmcda
                 dgllvmpta dgllvmdda dgpta dgdda dganalysis
-		dgllvmforkjoin dgllvmsdg
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                dgllvmforkjoin dgsdg dgllvmsdg
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 endif(LLVM_DG)

--- a/tests/slicing/test-runner.py
+++ b/tests/slicing/test-runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from sys import stdout, argv
 from subprocess import Popen, PIPE

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -134,7 +134,7 @@ endif (HAVE_SVF)
                                               PRIVATE ${llvm_analysis}
                                               PRIVATE ${llvm_support})
 
-	install(TARGETS llvm-dg-dump llvm-slicer
+	install(TARGETS llvm-slicer
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 	install(TARGETS dgllvmslicer
@@ -142,10 +142,6 @@ endif (HAVE_SVF)
 
 	install(FILES llvm-slicer.h llvm-slicer-opts.h llvm-slicer-utils.h
 		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dg/tools)
-
-	# copy also the wrapper scripts
-	install(FILES pta-show llvmdda-dump llvmdg-show dgtool
-		DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif (LLVM_DG)
 
 include_directories(../src)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -135,17 +135,17 @@ endif (HAVE_SVF)
                                               PRIVATE ${llvm_support})
 
 	install(TARGETS llvm-dg-dump llvm-slicer
-		RUNTIME DESTINATION bin)
+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 	install(TARGETS dgllvmslicer
-		LIBRARY DESTINATION lib)
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 	install(FILES llvm-slicer.h llvm-slicer-opts.h llvm-slicer-utils.h
 		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dg/tools)
 
 	# copy also the wrapper scripts
 	install(FILES pta-show llvmdda-dump llvmdg-show dgtool
-		DESTINATION bin)
+		DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif (LLVM_DG)
 
 include_directories(../src)

--- a/tools/dgtool
+++ b/tools/dgtool
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from subprocess import call
 from sys import argv, stderr, stdout, exit


### PR DESCRIPTION
This specfile template can be used with the `rpkg` tool, which can create a SRPM from a git repository. The resulting SRPM can be used with CentOS, Fedora, openSuse and Mageia. However, both openSuse and Mageia need some changes done to the build process of `dg`.