### PR TITLE
Fix some clang warnings

### DIFF
--- a/include/dg/ADT/NumberSet.h
+++ b/include/dg/ADT/NumberSet.h
@@ -129,7 +129,6 @@ public:
         }
 
         const_iterator(const const_iterator&) = default;
-        const_iterator& operator=(const const_iterator&) = default;
 
         const_iterator& operator++() {
             if (is_small)

--- a/include/dg/ReadWriteGraph/RWNode.h
+++ b/include/dg/ReadWriteGraph/RWNode.h
@@ -141,8 +141,9 @@ public:
     bool hasAddressTaken() const { return has_address_taken; }
     void setAddressTaken() { has_address_taken = true; }
 
-#ifndef NDEBUG
     virtual ~RWNode() = default;
+
+#ifndef NDEBUG
     void dump() const;
 #endif
 

--- a/lib/llvm/ControlDependence/InterproceduralCD.h
+++ b/lib/llvm/ControlDependence/InterproceduralCD.h
@@ -109,7 +109,7 @@ public:
     ValVec getDependencies(const llvm::BasicBlock *b) override { return {}; }
     ValVec getDependent(const llvm::BasicBlock *) override { return {}; }
 
-    void run() { /* we run on demand */ }
+    void run() override { /* we run on demand */ }
 };
 
 } // namespace llvmdg


### PR DESCRIPTION
- ReadWriteGraph/RWNode.h: Fix '-Wdelete-non-abstract-non-virtual-dtor'
- InterproceduralCD.h: Fix '-Winconsistent-missing-override'
- include/dg/ADT/NumberSet.h: Fix '-Wdefaulted-function-deleted' 