### PR TITLE
Test suite improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,19 @@ tags
 # LLVM files
 *.bc
 *.sliced
+*.linked
+*.opt
+*.ll
 
 *.i
 
 tests/*-test
+
+# clang
+.clangd
+
+# pycache
+__pycache__
 
 # C files in tools are test codes
 tools/*.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,10 @@ install:
   - cd ..
 
 script:
-  # gcc in the versions that we use has problems with sanitizers
-  - if test "$CXX" = "clang++"; then export CXX_FLAGS="-fsanitize=undefined,address"; fi
-  - cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DCMAKE_CXX_FLAGS=$CXX_FLAGS .
+  - cmake -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DUSE_SANITIZERS=ON .
   - make -j2
-  - cd tests
-  - make
   # for now turn off the detection of leaks, we're working on it
-  - ASAN_OPTIONS=detect_leaks=0 make check
+  - ASAN_OPTIONS=detect_leaks=0 make check -j2
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,12 @@ addons:
       - libz-dev
 
 env:
-    - LLVM=3.8
-    - LLVM=4.0
-    - LLVM=5.0
+    - LLVM=3.8 BUILD_TYPE=Release
+    - LLVM=3.8 BUILD_TYPE=Debug
+    - LLVM=4.0 BUILD_TYPE=Release
+    - LLVM=4.0 BUILD_TYPE=Debug
+    - LLVM=5.0 BUILD_TYPE=Release
+    - LLVM=5.0 BUILD_TYPE=Debug
 
 compiler:
     - 'clang++'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,20 +115,22 @@ endif()
 
 message(STATUS "Using compiler: ${CMAKE_CXX_COMPILER}")
 
+# Fuzzing
+include(CheckCXXCompilerFlag)
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer")
+check_cxx_source_compiles(
+	"#include <cstddef>
+	extern \"C\"
+	int LLVMFuzzerTestOneInput(const void * /*d*/, size_t /*s*/) { return 0; }"
+	fuzzer_works)
+set(CMAKE_REQUIRED_FLAGS "")
 
-# Our CI does not work with fuzzing tests yet, make it optional by hand
-option(TESTING_ENABLE_FUZZING "Enable fuzzing tests" off)
-if (TESING_ENABLE_FUZZING)
-	message(STATUS "Going to build fuzzing tests")
+if (fuzzer_works)
+	option(TESTING_ENABLE_FUZZING "Enable fuzzing tests" ON)
+	message(STATUS "Will build fuzzing tests")
+else()
+	message(STATUS "Will NOT build fuzzing tests (available only with Clang 6 or newer)")
 endif()
-#if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-	# FIXME: we should check for the version of clang
-	# or rather just whether -fsanitize=fuzzer works
-	#option(TESTING_ENABLE_FUZZING "Enable fuzzing tests" on)
-	#message(STATUS "Will build fuzzing tests")
-#else()
-#	message(STATUS "Will NOT build fuzzing tests")
-#endif()
 
 # explicitly add -std=c++11 (-std=c++14) and -fno-rtti
 # we have CMAKE_CXX_STANDARD, but for some reason it does not

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,16 @@ if (USE_CLANG_SANITIZERS)
 endif()
 
 if (USE_SANITIZERS)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined,address")
-	add_definitions(-DUSING_SANITIZERS)
+	set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined,address") # for linker
+	check_cxx_compiler_flag("-fsanitize=undefined,address" sanitizers_work)
+	set(CMAKE_REQUIRED_FLAGS "")
+
+	if (sanitizers_work)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined,address")
+		add_definitions(-DUSING_SANITIZERS)
+	else()
+		message(WARNING "Used compiler does not support sanitizers or its support is incomplete.")
+	endif()
 endif()
 
 # Debug Release RelWithDebInfo MinSizeRel.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,0 @@
-sources/*.bc
-sources/*.sliced
-sources/*.linked

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ if(N EQUAL 0)
     set(N 1)
 endif()
 
-set(CTEST_OPTS -j${N} ${CTEST_OPTS})
+set(CTEST_OPTS -j${N} --output-on-failure --progress ${CTEST_OPTS})
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_OPTS})
 
 # --------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 # add check target
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+enable_testing()
+
+include(ProcessorCount)
+ProcessorCount(N)
+if(N EQUAL 0)
+    set(N 1)
+endif()
+
+set(CTEST_OPTS -j${N} ${CTEST_OPTS})
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_OPTS})
 
 # --------------------------------------------------
 # points-to-test

--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -9,7 +9,8 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 # --------------------------------------------------
 add_executable(numbers-set1 numbers-set1.cpp)
 add_dependencies(check numbers-set1)
-add_test(numbers-set1-fuzzing numbers-set1 regressions/numbers-set1 -runs=100000)
+add_test(numbers-set1-fuzzing numbers-set1
+    ${CMAKE_CURRENT_SOURCE_DIR}/regressions/numbers-set1 -runs=100000)
 
 add_executable(bitvector1 bitvector1.cpp)
 add_dependencies(check bitvector1)
@@ -17,5 +18,6 @@ add_test(bitvector1-fuzzing bitvector1 -runs=100000)
 
 add_executable(disjunctive-map1 disjunctive-map1.cpp)
 add_dependencies(check disjunctive-map1)
-add_test(disjunctive-map1-fuzzing disjunctive-map1 regressions/disjunctive-map1 -runs=20000)
+add_test(disjunctive-map1-fuzzing disjunctive-map1
+    ${CMAKE_CURRENT_SOURCE_DIR}/regressions/disjunctive-map1 -runs=20000)
 

--- a/tests/slicing/test-runner.py
+++ b/tests/slicing/test-runner.py
@@ -78,7 +78,7 @@ def compile(source, output = None, params=[]):
     ret = command(["clang", "-include", join(SOURCESDIR, '..', "test_assert.h"),
                    "-emit-llvm", "-c", source, "-o", output] + params)
     if ret != 0:
-        error('Failed executing command')
+        error('Failed executing clang')
 
     return output
 
@@ -88,7 +88,8 @@ def slice(bccode, args):
     cmd.append(bccode)
     cmd += ["-o", output]
 
-    command(cmd)
+    if command(cmd) != 0:
+        error('Failed executing llvm-slicer')
 
     return output
 
@@ -96,14 +97,20 @@ def link(bccode, codes, output = None):
     if output is None:
         output = bccode + ".linked"
     cmd = ["llvm-link", bccode, "-o", output] + codes
-    command(cmd)
+
+    if command(cmd) != 0:
+        error('Failed executing llvm-link')
+
     return output
 
 def opt(bccode, passes, output = None):
     if output is None:
         output = bccode + ".opt"
     cmd = ["opt", bccode, "-o", output] + passes
-    command(cmd)
+
+    if command(cmd) != 0:
+        error('Failed executing opt')
+
     return output
 
 def check_output(out, expout):

--- a/tests/slicing/test-runner.py
+++ b/tests/slicing/test-runner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from sys import stdout, argv
-from subprocess import Popen, PIPE
+from subprocess import Popen, DEVNULL, PIPE
 from os.path import join, dirname, abspath
 from os import unlink, chdir, getcwd
 
@@ -40,7 +40,7 @@ def command(cmd):
     if debug:
         p = Popen(cmd)
     else:
-        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        p = Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
     return p.wait()
 
 def command_output(cmd):

--- a/tests/thread-regions-test.cpp
+++ b/tests/thread-regions-test.cpp
@@ -31,12 +31,15 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <memory>
 #include <queue>
 #include <string>
 
+using NodePtr = std::unique_ptr<Node>;
+
 TEST_CASE("Test of node class methods", "[node]") {
-    Node * node0 = createNode<NodeType::GENERAL>();
-    Node * node1 = createNode<NodeType::CALL>();
+    NodePtr node0(createNode<NodeType::GENERAL>()),
+            node1(createNode<NodeType::CALL>());
 
     REQUIRE(node0->isArtificial());
     REQUIRE(node0->getType() == NodeType::GENERAL);
@@ -48,17 +51,17 @@ TEST_CASE("Test of node class methods", "[node]") {
     }
 
     SECTION("createNode creates the rightNode") {
-        auto General = createNode<NodeType::GENERAL>();
-        auto Fork = createNode<NodeType::FORK>();
-        auto Join = createNode<NodeType::JOIN>();
-        auto Lock = createNode<NodeType::LOCK>();
-        auto Unlock = createNode<NodeType::UNLOCK>();
-        auto Entry = createNode<NodeType::ENTRY>();
-        auto Exit = createNode<NodeType::EXIT>();
-        auto Call = createNode<NodeType::CALL>();
-        auto CallReturn = createNode<NodeType::CALL_RETURN>();
-        auto CallFuncPtr = createNode<NodeType::CALL_FUNCPTR>(nullptr);
-        auto Return = createNode<NodeType::RETURN>();
+        NodePtr General(createNode<NodeType::GENERAL>()),
+                Fork(createNode<NodeType::FORK>()),
+                Join(createNode<NodeType::JOIN>()),
+                Lock(createNode<NodeType::LOCK>()),
+                Unlock(createNode<NodeType::UNLOCK>()),
+                Entry(createNode<NodeType::ENTRY>()),
+                Exit(createNode<NodeType::EXIT>()),
+                Call(createNode<NodeType::CALL>()),
+                CallReturn(createNode<NodeType::CALL_RETURN>()),
+                CallFuncPtr(createNode<NodeType::CALL_FUNCPTR>(nullptr)),
+                Return(createNode<NodeType::RETURN>());
 
         REQUIRE(General->getType() == NodeType::GENERAL);
         REQUIRE(Fork->getType() == NodeType::FORK);
@@ -107,12 +110,12 @@ TEST_CASE("Test of node class methods", "[node]") {
 
     SECTION("add new successor increases size of successors"
             " of node0 and size of predecessors of node 1") {
-        REQUIRE(node0->addSuccessor(node1));
+        REQUIRE(node0->addSuccessor(node1.get()));
         REQUIRE(node0->successors().size() == 1);
         REQUIRE(node1->predecessors().size() == 1);
 
         SECTION("adding the same successor for the second time does nothing") {
-            REQUIRE_FALSE(node0->addSuccessor(node1));
+            REQUIRE_FALSE(node0->addSuccessor(node1.get()));
             REQUIRE(node0->successors().size() == 1);
             REQUIRE(node1->predecessors().size() == 1);
         }
@@ -122,34 +125,34 @@ TEST_CASE("Test of node class methods", "[node]") {
     SECTION("Removing node1 from successors of node0"
             " decreases size of successors of node0 and predecessors of node1") {
         REQUIRE(node0->successors().empty());
-        REQUIRE(node0->addSuccessor(node1));
-        auto foundNodeIterator = node0->successors().find(node1);
+        REQUIRE(node0->addSuccessor(node1.get()));
+        auto foundNodeIterator = node0->successors().find(node1.get());
         REQUIRE_FALSE(foundNodeIterator == node0->successors().end());
         REQUIRE(node0->successors().size() == 1);
-        REQUIRE(node0->removeSuccessor(node1));
+        REQUIRE(node0->removeSuccessor(node1.get()));
         REQUIRE(node0->successors().empty());
     }
 
     SECTION("Removing nonexistent successor does nothing") {
         REQUIRE(node0->successors().empty());
-        REQUIRE_FALSE(node0->removeSuccessor(node1));
+        REQUIRE_FALSE(node0->removeSuccessor(node1.get()));
         REQUIRE(node0->successors().empty());
-        Node * node2 = createNode<NodeType::GENERAL>();
-        REQUIRE(node0->addSuccessor(node1));
+        NodePtr node2(createNode<NodeType::GENERAL>());
+        REQUIRE(node0->addSuccessor(node1.get()));
         REQUIRE(node0->successors().size() == 1);
-        REQUIRE_FALSE(node0->removeSuccessor(node2));
+        REQUIRE_FALSE(node0->removeSuccessor(node2.get()));
         REQUIRE(node0->successors().size() == 1);
     }
 
     SECTION("add new predecessor increases size of predecessors"
             " of node0 and size of successors of node 1") {
         REQUIRE(node0->predecessors().empty());
-        REQUIRE(node0->addPredecessor(node1));
+        REQUIRE(node0->addPredecessor(node1.get()));
         REQUIRE(node0->predecessors().size() == 1);
         REQUIRE(node1->successors().size() == 1);
 
         SECTION("adding the same predecessor for the second time does nothing") {
-            REQUIRE_FALSE(node0->addPredecessor(node1));
+            REQUIRE_FALSE(node0->addPredecessor(node1.get()));
             REQUIRE(node0->predecessors().size() == 1);
             REQUIRE(node1->successors().size() == 1);
         }
@@ -158,22 +161,22 @@ TEST_CASE("Test of node class methods", "[node]") {
     SECTION("Removing node1 from predecessors of node0"
             " decreases size of successors of node0 and predecessors of node1") {
         REQUIRE(node0->successors().empty());
-        REQUIRE(node0->addPredecessor(node1));
-        auto foundNodeIterator = node0->predecessors().find(node1);
+        REQUIRE(node0->addPredecessor(node1.get()));
+        auto foundNodeIterator = node0->predecessors().find(node1.get());
         REQUIRE_FALSE(foundNodeIterator == node0->predecessors().end());
         REQUIRE(node0->predecessors().size() == 1);
-        REQUIRE(node0->removePredecessor(node1));
+        REQUIRE(node0->removePredecessor(node1.get()));
         REQUIRE(node0->successors().empty());
     }
 
     SECTION("Removing nonexistent predecessor does nothing") {
         REQUIRE(node0->predecessors().empty());
-        REQUIRE_FALSE(node0->removePredecessor(node1));
+        REQUIRE_FALSE(node0->removePredecessor(node1.get()));
         REQUIRE(node0->successors().empty());
-        Node * node2 = createNode<NodeType::GENERAL>();
-        REQUIRE(node0->addPredecessor(node1));
+        NodePtr node2(createNode<NodeType::GENERAL>());
+        REQUIRE(node0->addPredecessor(node1.get()));
         REQUIRE(node0->predecessors().size() == 1);
-        REQUIRE_FALSE(node0->removePredecessor(node2));
+        REQUIRE_FALSE(node0->removePredecessor(node2.get()));
         REQUIRE(node0->predecessors().size() == 1);
     }
 
@@ -203,10 +206,11 @@ TEST_CASE("Test of node class methods", "[node]") {
 }
 
 TEST_CASE("Test of ThreadRegion class methods", "[ThreadRegion]") {
-    auto node0 = createNode<NodeType::GENERAL>();
-    auto node1 = createNode<NodeType::GENERAL>();
-    ThreadRegion * threadRegion0 = new ThreadRegion(node0);
-    ThreadRegion * threadRegion1 = new ThreadRegion(node1);
+    NodePtr node0(createNode<NodeType::GENERAL>()),
+            node1(createNode<NodeType::GENERAL>());
+
+    std::unique_ptr<ThreadRegion> threadRegion0(new ThreadRegion(node0.get())),
+                                  threadRegion1(new ThreadRegion(node1.get()));
 
     REQUIRE(threadRegion0->successors().empty());
     REQUIRE(threadRegion1->successors().empty());
@@ -221,37 +225,37 @@ TEST_CASE("Test of ThreadRegion class methods", "[ThreadRegion]") {
     }
 
     SECTION("Add successor") {
-        REQUIRE(threadRegion0->addSuccessor(threadRegion1));
+        REQUIRE(threadRegion0->addSuccessor(threadRegion1.get()));
         REQUIRE(threadRegion0->successors().size() == 1);
         REQUIRE(threadRegion1->predecessors().size() == 1);
     }
 
     SECTION("Add predecessor") {
-        REQUIRE(threadRegion0->addPredecessor(threadRegion1));
+        REQUIRE(threadRegion0->addPredecessor(threadRegion1.get()));
         REQUIRE(threadRegion0->predecessors().size() == 1);
         REQUIRE(threadRegion1->successors().size() == 1);
     }
 
     SECTION("Remove existing successor") {
-        threadRegion0->addSuccessor(threadRegion1);
+        threadRegion0->addSuccessor(threadRegion1.get());
         REQUIRE(threadRegion0->successors().size() == 1);
-        REQUIRE(threadRegion0->removeSuccessor(threadRegion1));
+        REQUIRE(threadRegion0->removeSuccessor(threadRegion1.get()));
         REQUIRE(threadRegion0->successors().empty());
     }
 
     SECTION("Removing existing predecessor") {
-        threadRegion0->addPredecessor(threadRegion1);
+        threadRegion0->addPredecessor(threadRegion1.get());
         REQUIRE(threadRegion0->predecessors().size() == 1);
-        REQUIRE(threadRegion0->removePredecessor(threadRegion1));
+        REQUIRE(threadRegion0->removePredecessor(threadRegion1.get()));
         REQUIRE(threadRegion0->predecessors().size() == 0);
     }
 
     SECTION("Removing nonexistent successor") {
-        REQUIRE_FALSE(threadRegion0->removeSuccessor(threadRegion1));
+        REQUIRE_FALSE(threadRegion0->removeSuccessor(threadRegion1.get()));
     }
 
     SECTION("Removing nonexistent predecessor") {
-        REQUIRE_FALSE(threadRegion0->removePredecessor(threadRegion1));
+        REQUIRE_FALSE(threadRegion0->removePredecessor(threadRegion1.get()));
     }
 
     SECTION("Remove nullptr from successor") {
@@ -264,47 +268,47 @@ TEST_CASE("Test of ThreadRegion class methods", "[ThreadRegion]") {
 }
 
 TEST_CASE("Test of EntryNode class methods", "[EntryNode]") {
-    ForkNode * forkNode = createNode<NodeType::FORK>();
-    EntryNode * entryNode = createNode<NodeType::ENTRY>();
+    std::unique_ptr<ForkNode> forkNode(createNode<NodeType::FORK>());
+    std::unique_ptr<EntryNode> entryNode(createNode<NodeType::ENTRY>());
 
     SECTION("Add fork predecessor") {
-        REQUIRE(entryNode->addForkPredecessor(forkNode));
+        REQUIRE(entryNode->addForkPredecessor(forkNode.get()));
         REQUIRE(entryNode->forkPredecessors().size() == 1);
-        REQUIRE_FALSE(entryNode->addForkPredecessor(forkNode));
+        REQUIRE_FALSE(entryNode->addForkPredecessor(forkNode.get()));
         REQUIRE(entryNode->forkPredecessors().size() == 1);
         REQUIRE_FALSE(entryNode->addForkPredecessor(nullptr));
         REQUIRE(entryNode->forkPredecessors().size() == 1);
     }
 
     SECTION("Remove fork predecessor") {
-        entryNode->addForkPredecessor(forkNode);
+        entryNode->addForkPredecessor(forkNode.get());
         REQUIRE(entryNode->forkPredecessors().size() == 1);
-        REQUIRE(entryNode->removeForkPredecessor(forkNode));
+        REQUIRE(entryNode->removeForkPredecessor(forkNode.get()));
         REQUIRE(entryNode->forkPredecessors().size() == 0);
-        REQUIRE_FALSE(entryNode->removeForkPredecessor(forkNode));
+        REQUIRE_FALSE(entryNode->removeForkPredecessor(forkNode.get()));
         REQUIRE(entryNode->forkPredecessors().size() == 0);
     }
 }
 
 TEST_CASE("Test of ExitNode class methods", "[ExitNode]") {
-    auto joinNode = createNode<NodeType::JOIN>();
-    auto exitNode = createNode<NodeType::EXIT>();
+    std::unique_ptr<JoinNode> joinNode(createNode<NodeType::JOIN>());
+    std::unique_ptr<ExitNode> exitNode(createNode<NodeType::EXIT>());
 
     SECTION("Add join successor") {
-        REQUIRE(exitNode->addJoinSuccessor(joinNode));
+        REQUIRE(exitNode->addJoinSuccessor(joinNode.get()));
         REQUIRE(exitNode->joinSuccessors().size() == 1);
-        REQUIRE_FALSE(exitNode->addJoinSuccessor(joinNode));
+        REQUIRE_FALSE(exitNode->addJoinSuccessor(joinNode.get()));
         REQUIRE(exitNode->joinSuccessors().size() == 1);
         REQUIRE_FALSE(exitNode->addJoinSuccessor(nullptr));
         REQUIRE(exitNode->joinSuccessors().size() == 1);
     }
 
     SECTION("Remove join successor") {
-        exitNode->addJoinSuccessor(joinNode);
+        exitNode->addJoinSuccessor(joinNode.get());
         REQUIRE(exitNode->joinSuccessors().size() == 1);
-        REQUIRE(exitNode->removeJoinSuccessor(joinNode));
+        REQUIRE(exitNode->removeJoinSuccessor(joinNode.get()));
         REQUIRE(exitNode->joinSuccessors().size() == 0);
-        REQUIRE_FALSE(exitNode->removeJoinSuccessor(joinNode));
+        REQUIRE_FALSE(exitNode->removeJoinSuccessor(joinNode.get()));
         REQUIRE(exitNode->joinSuccessors().size() == 0);
         REQUIRE_FALSE(exitNode->removeJoinSuccessor(nullptr));
         REQUIRE(exitNode->joinSuccessors().size() == 0);
@@ -312,34 +316,34 @@ TEST_CASE("Test of ExitNode class methods", "[ExitNode]") {
 }
 
 TEST_CASE("Test of ForkNode class methods", "[ForkNode]") {
-    auto forkNode = createNode<NodeType::FORK>();
-    auto joinNode = createNode<NodeType::JOIN>();
-    auto entryNode = createNode<NodeType::ENTRY>();
+    std::unique_ptr<ForkNode> forkNode(createNode<NodeType::FORK>());
+    std::unique_ptr<JoinNode> joinNode(createNode<NodeType::JOIN>());
+    std::unique_ptr<EntryNode> entryNode(createNode<NodeType::ENTRY>());
 
     SECTION("Add corresponding join") {
-        REQUIRE(forkNode->addCorrespondingJoin(joinNode));
+        REQUIRE(forkNode->addCorrespondingJoin(joinNode.get()));
         REQUIRE(forkNode->correspondingJoins().size() == 1);
-        REQUIRE_FALSE(forkNode->addCorrespondingJoin(joinNode));
+        REQUIRE_FALSE(forkNode->addCorrespondingJoin(joinNode.get()));
         REQUIRE(forkNode->correspondingJoins().size() == 1);
         REQUIRE_FALSE(forkNode->addCorrespondingJoin(nullptr));
         REQUIRE(forkNode->correspondingJoins().size() == 1);
     }
 
     SECTION("Add fork successor") {
-        REQUIRE(forkNode->addForkSuccessor(entryNode));
+        REQUIRE(forkNode->addForkSuccessor(entryNode.get()));
         REQUIRE(forkNode->forkSuccessors().size() == 1);
-        REQUIRE_FALSE(forkNode->addForkSuccessor(entryNode));
+        REQUIRE_FALSE(forkNode->addForkSuccessor(entryNode.get()));
         REQUIRE(forkNode->forkSuccessors().size() == 1);
         REQUIRE_FALSE(forkNode->addForkSuccessor(nullptr));
         REQUIRE(forkNode->forkSuccessors().size() == 1);
     }
 
     SECTION("Remove fork successor") {
-        forkNode->addForkSuccessor(entryNode);
+        forkNode->addForkSuccessor(entryNode.get());
         REQUIRE(forkNode->forkSuccessors().size() == 1);
-        REQUIRE(forkNode->removeForkSuccessor(entryNode));
+        REQUIRE(forkNode->removeForkSuccessor(entryNode.get()));
         REQUIRE(forkNode->forkSuccessors().size() == 0);
-        REQUIRE_FALSE(forkNode->removeForkSuccessor(entryNode));
+        REQUIRE_FALSE(forkNode->removeForkSuccessor(entryNode.get()));
         REQUIRE(forkNode->forkSuccessors().size() == 0);
         REQUIRE_FALSE(forkNode->removeForkSuccessor(nullptr));
         REQUIRE(forkNode->forkSuccessors().size() == 0);
@@ -347,35 +351,35 @@ TEST_CASE("Test of ForkNode class methods", "[ForkNode]") {
 }
 
 TEST_CASE("Test of JoinNode class methods", "[JoinNode]") {
-    auto joinNode = createNode<NodeType::JOIN>();
-    auto forkNode = createNode<NodeType::FORK>();
-    auto exitNode = createNode<NodeType::EXIT>();
+    std::unique_ptr<JoinNode> joinNode(createNode<NodeType::JOIN>());
+    std::unique_ptr<ForkNode> forkNode(createNode<NodeType::FORK>());
+    std::unique_ptr<ExitNode> exitNode(createNode<NodeType::EXIT>());
 
 
     SECTION("Add corresponding fork") {
-        REQUIRE(joinNode->addCorrespondingFork(forkNode));
+        REQUIRE(joinNode->addCorrespondingFork(forkNode.get()));
         REQUIRE(joinNode->correspondingForks().size() == 1);
-        REQUIRE_FALSE(joinNode->addCorrespondingFork(forkNode));
+        REQUIRE_FALSE(joinNode->addCorrespondingFork(forkNode.get()));
         REQUIRE(joinNode->correspondingForks().size() == 1);
         REQUIRE_FALSE(joinNode->addCorrespondingFork(nullptr));
         REQUIRE(joinNode->correspondingForks().size() == 1);
     }
 
     SECTION("Add join predecessor") {
-        REQUIRE(joinNode->addJoinPredecessor(exitNode));
+        REQUIRE(joinNode->addJoinPredecessor(exitNode.get()));
         REQUIRE(joinNode->joinPredecessors().size() == 1);
-        REQUIRE_FALSE(joinNode->addJoinPredecessor(exitNode));
+        REQUIRE_FALSE(joinNode->addJoinPredecessor(exitNode.get()));
         REQUIRE(joinNode->joinPredecessors().size() == 1);
         REQUIRE_FALSE(joinNode->addJoinPredecessor(nullptr));
         REQUIRE(joinNode->joinPredecessors().size() == 1);
     }
 
     SECTION("Remove join predecessor") {
-        joinNode->addJoinPredecessor(exitNode);
+        joinNode->addJoinPredecessor(exitNode.get());
         REQUIRE(joinNode->joinPredecessors().size() == 1);
-        REQUIRE(joinNode->removeJoinPredecessor(exitNode));
+        REQUIRE(joinNode->removeJoinPredecessor(exitNode.get()));
         REQUIRE(joinNode->joinPredecessors().size() == 0);
-        REQUIRE_FALSE(joinNode->removeJoinPredecessor(exitNode));
+        REQUIRE_FALSE(joinNode->removeJoinPredecessor(exitNode.get()));
         REQUIRE(joinNode->joinPredecessors().size() == 0);
         REQUIRE_FALSE(joinNode->removeJoinPredecessor(nullptr));
         REQUIRE(joinNode->joinPredecessors().size() == 0);
@@ -383,13 +387,13 @@ TEST_CASE("Test of JoinNode class methods", "[JoinNode]") {
 }
 
 TEST_CASE("Test of LockNode class methods", "[LockNode]") {
-    auto lockNode = createNode<NodeType::LOCK>();
-    auto unlockNode = createNode<NodeType::UNLOCK>();
+    std::unique_ptr<LockNode> lockNode(createNode<NodeType::LOCK>());
+    std::unique_ptr<UnlockNode> unlockNode(createNode<NodeType::UNLOCK>());
 
     SECTION("Add corresponding unlock") {
-        REQUIRE(lockNode->addCorrespondingUnlock(unlockNode));
+        REQUIRE(lockNode->addCorrespondingUnlock(unlockNode.get()));
         REQUIRE(lockNode->correspondingUnlocks().size() == 1);
-        REQUIRE_FALSE(lockNode->addCorrespondingUnlock(unlockNode));
+        REQUIRE_FALSE(lockNode->addCorrespondingUnlock(unlockNode.get()));
         REQUIRE(lockNode->correspondingUnlocks().size() == 1);
         REQUIRE_FALSE(lockNode->addCorrespondingUnlock(nullptr));
         REQUIRE(lockNode->correspondingUnlocks().size() == 1);
@@ -570,15 +574,12 @@ TEST_CASE("GraphBuilder build tests", "[GraphBuilder]") {
     }
 
     SECTION("ForkNode iterator test") {
-        auto forkNode = createNode<NodeType::FORK>();
+        std::unique_ptr<ForkNode> forkNode(createNode<NodeType::FORK>());
+        std::unique_ptr<EntryNode> entryNode0(createNode<NodeType::ENTRY>());
+        NodePtr node0(createNode<NodeType::GENERAL>());
 
-        auto entryNode0 = createNode<NodeType::ENTRY>();
-
-        forkNode->addForkSuccessor(entryNode0);
-
-        auto node0 = createNode<NodeType::GENERAL>();
-
-        forkNode->addSuccessor(node0);
+        forkNode->addForkSuccessor(entryNode0.get());
+        forkNode->addSuccessor(node0.get());
 
         int i = 0;
 


### PR DESCRIPTION
Needs Python 3 related changes from #326, otherwise CI fails.

- tests/slicing/test-runner.py: Fail if any subcommand fails
- tests/thread-regions-test.cpp: Fix memory leaks
- CMakeLists.txt: Enable fuzzing tests only for compilers supporting it
- tests/slicing/test-runner.py: Fix deadlock when pipes become full
- CMakeLists.txt: Warn when compiler does not support sanitizers
- tests/fuzzing/CMakeLists.txt: Fix path to regressions
- tests: Allow parallel testing by default
- .travis.yml: Reflect recent commits
- tests/CMakeLists.txt: Show test info and output only on failure