### PR TITLE
NodesWalk.h: Fix '-Wmissing-field-initializers' warning

### DIFF
--- a/include/dg/NodesWalk.h
+++ b/include/dg/NodesWalk.h
@@ -9,7 +9,7 @@ namespace dg {
 // universal but not very efficient visits tracker
 template <typename Node>
 struct SetVisitTracker {
-    std::set<Node *> _visited;
+    std::set<Node *> _visited{};
 
     void visit(Node *n) { _visited.insert(n); }
     bool visited(Node *n) const { return _visited.count(n); }


### PR DESCRIPTION
Fixes:

[  8%] Building CXX object tests/CMakeFiles/bitvector-test.dir/bitvector-test.cpp.o
In file included from /dg/tests/nodes-walk-test.cpp:4:0:
/dg/include/dg/NodesWalk.h: In constructor ‘dg::NodesWalk<Node, Queue, VisitTracker, EdgeChooser>::NodesWalk() [with Node = Node; Queue = dg::ADT::QueueLIFO<Node*>; VisitTracker = dg::SetVisitTracker<Node>; EdgeChooser = dg::SuccessorsEdgeChooser<Node>]’:
/dg/include/dg/NodesWalk.h:109:5: warning: missing initializer for member ‘dg::SetVisitTracker<Node>::_visited’ [-Wmissing-field-initializers]
     NodesWalk() = default;
     ^
...