### PR TITLE
build: install also libdgcda

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -246,7 +246,7 @@ else()
 				PUBLIC dgllvmcda)
 endif(APPLE)
 
-install(TARGETS dgllvmdg dgllvmthreadregions dgllvmcda
+install(TARGETS dgllvmdg dgllvmthreadregions dgllvmcda dgcda
                 dgllvmpta dgllvmdda dgpta dgdda dganalysis
                 dgllvmforkjoin dgsdg dgllvmsdg
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
This allows to start sbt-slicer in new version of Symbiotic.