### PR TITLE
CI: Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/hash_map.yml
+++ b/.github/workflows/hash_map.yml
@@ -1,0 +1,94 @@
+---
+name: DG + External Hash Maps
+on: [push, pull_request]
+
+jobs:
+  Ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        hashmap: [tsl-hopscotch]
+
+    runs-on: ubuntu-20.04
+    env:
+      # for colours in ninja
+      CLICOLOR_FORCE: 1
+
+    steps:
+      - name: Checkout DG
+        uses: actions/checkout@v2
+
+      - name: Checkout TSL Hopscotch
+        uses: actions/checkout@v2
+        with:
+          repository: Tessil/hopscotch-map
+          path: tsl-hopscotch
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ccache cmake ninja-build clang-10 llvm-10-dev
+
+      - name: Set environment
+        id: env
+        run: |
+          # set expected name of selected hashmap
+          case "${{matrix.hashmap}}" in
+            "tsl-hopscotch") echo "HASHMAP=TSL_HOPSCOTCH_DIR" >> $GITHUB_ENV;;
+            *) echo "Unknown hashmap selected." && exit 1;;
+          esac
+
+          if [[ "${{matrix.compiler}}" = "clang" ]]; then
+            echo "CC=clang-10" >> $GITHUB_ENV
+            echo "CXX=clang++-10" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+          fi
+
+          # set up ccache
+          sudo /usr/sbin/update-ccache-symlinks
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
+
+          echo "::set-output name=timestamp::$(date -u -Iseconds)"
+
+      - name: Set up ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ubuntu-20.04-${{matrix.hashmap}}-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ubuntu-20.04-${{matrix.hashmap}}-${{matrix.compiler}}
+
+      - name: Configure CMake project
+        run: |
+          cmake -S. \
+                -B_build \
+                -GNinja \
+                -DUSE_SANITIZERS:BOOL=ON \
+                -DLLVM_DIR:PATH="$(llvm-config-10 --cmakedir)" \
+                -D${HASHMAP}:PATH="$GITHUB_WORKSPACE/${{matrix.hashmap}}"
+
+      - name: Build
+        run: cmake --build _build
+
+      - name: Run tests
+        # TODO: turn off the detection of leaks, we're working on it
+        run: ASAN_OPTIONS=detect_leaks=0 cmake --build _build --target check
+
+      - name: ccache statistics
+        run: ccache -s

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,212 @@
+---
+name: Linux CI
+on: [push, pull_request]
+
+jobs:
+  build64:
+    name: Ubuntu 64-bit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # LLVM 3.4 is not available
+          # LLVM 3.{5,6} are not compatible at the moment
+
+          # Linux with GCC
+          # - {os: ubuntu-16.04, llvm: '3.5', compiler: gcc}
+          # - {os: ubuntu-16.04, llvm: '3.6', compiler: gcc}
+          - {os: ubuntu-16.04, llvm: '3.7', compiler: gcc}
+          - {os: ubuntu-16.04, llvm: '3.8', compiler: gcc}
+          - {os: ubuntu-16.04, llvm: '3.9', compiler: gcc}
+          - {os: ubuntu-16.04, llvm: '4.0', compiler: gcc}
+          - {os: ubuntu-18.04, llvm: '5.0', compiler: gcc}
+          - {os: ubuntu-18.04, llvm: '6.0', compiler: gcc}
+          - {os: ubuntu-18.04, llvm: 7, compiler: gcc}
+          - {os: ubuntu-18.04, llvm: 8, compiler: gcc}
+          - {os: ubuntu-18.04, llvm: 9, compiler: gcc}
+          - {os: ubuntu-20.04, llvm: 10, compiler: gcc}
+          - {os: ubuntu-20.04, llvm: 11, compiler: gcc}
+          - {os: ubuntu-20.04, llvm: 12, compiler: gcc}
+          - {os: ubuntu-20.04, llvm: 12, compiler: gcc, type: Debug}
+
+          # Linux with Clang
+          # - {os: ubuntu-16.04, llvm: '3.5', compiler: clang}
+          # - {os: ubuntu-16.04, llvm: '3.6', compiler: clang}
+          - {os: ubuntu-16.04, llvm: '3.7', compiler: clang}
+          - {os: ubuntu-16.04, llvm: '3.8', compiler: clang}
+          - {os: ubuntu-16.04, llvm: '3.9', compiler: clang}
+          - {os: ubuntu-16.04, llvm: '4.0', compiler: clang}
+          - {os: ubuntu-18.04, llvm: '5.0', compiler: clang}
+          - {os: ubuntu-18.04, llvm: '6.0', compiler: clang}
+          - {os: ubuntu-18.04, llvm: 7, compiler: clang}
+          - {os: ubuntu-18.04, llvm: 8, compiler: clang}
+          - {os: ubuntu-18.04, llvm: 9, compiler: clang}
+          - {os: ubuntu-20.04, llvm: 10, compiler: clang}
+          - {os: ubuntu-20.04, llvm: 11, compiler: clang}
+          - {os: ubuntu-20.04, llvm: 12, compiler: clang}
+          - {os: ubuntu-20.04, llvm: 12, compiler: clang, type: Debug}
+
+    runs-on: ${{matrix.os}}
+    env:
+      # for colours in ninja
+      CLICOLOR_FORCE: 1
+
+    steps:
+      - name: Checkout DG
+        uses: actions/checkout@v2
+
+      - name: '[LLVM 11] Add repositories'
+        if: matrix.llvm == 11
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+
+      - name: '[LLVM 12] Add repositories'
+        if: matrix.llvm == 12
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main"
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ccache cmake ninja-build clang-${{matrix.llvm}} \
+                           llvm-${{matrix.llvm}}-dev
+
+      - name: '[Xenial + LLVM 3.8] Fix installation'
+        if: matrix.os == 'ubuntu-16.04' && matrix.llvm == '3.8'
+        run: |
+          # patch LLVMConfig.cmake + LLVMExports-relwithdebinfo.cmake
+          sudo patch -d/ -p0 < .github/workflows/xenial-llvm3.8/cmake.patch
+
+          # fix paths to libraries and headers
+          sudo ln -s /usr/include/llvm-c-3.8/llvm-c /usr/include/llvm-3.8/llvm-c
+          sudo cp -P /usr/lib/llvm-3.8/lib/libLLVM-3.8.so /usr/lib/llvm-3.8/lib/libLLVM-3.8.so.1
+
+      - name: Get LLVM CMake directory
+        run: |
+          # older releases do not have (usable) llvm-config
+          if [[ "${{matrix.llvm}}" =~ ^3\.[0-8] ]]; then
+            echo "LLVM_CMAKE_DIR='/usr/share/llvm-${{matrix.llvm}}/cmake'" \
+                  >> $GITHUB_ENV
+          else
+            echo "LLVM_CMAKE_DIR='/usr/lib/llvm-${{matrix.llvm}}/lib/cmake/llvm'" \
+                  >> $GITHUB_ENV
+          fi
+
+      - name: Set environment
+        id: env
+        run: |
+          if [[ "${{matrix.compiler}}" = "clang" ]]; then
+            echo "CC=clang-${{matrix.llvm}}" >> $GITHUB_ENV
+            echo "CXX=clang++-${{matrix.llvm}}" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+          fi
+
+          # set up ccache
+          sudo /usr/sbin/update-ccache-symlinks
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+          # Xenial and Bionic do not create symlinks to versioned clang
+          sudo ln -sfr /usr/bin/ccache /usr/lib/ccache/clang-${{matrix.llvm}}
+          sudo ln -sfr /usr/bin/ccache /usr/lib/ccache/clang++-${{matrix.llvm}}
+
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
+
+          echo "::set-output name=timestamp::$(date -u -Iseconds)"
+
+      - name: Set up ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ${{matrix.os}}-${{matrix.llvm}}-${{matrix.compiler}}-${{matrix.type}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ${{matrix.os}}-${{matrix.llvm}}-${{matrix.compiler}}-${{matrix.type}}
+
+      - name: Configure CMake project
+        run: |
+          cmake -S. \
+                -B_build \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE:STRING="${{matrix.type}}" \
+                -DUSE_SANITIZERS:BOOL=ON \
+                -DLLVM_DIR:PATH="$LLVM_CMAKE_DIR"
+
+      - name: Build
+        run: cmake --build _build
+
+      - name: Run tests
+        # TODO: turn off the detection of leaks, we're working on it
+        run: ASAN_OPTIONS=detect_leaks=0 cmake --build _build --target check
+
+      - name: ccache statistics
+        run: ccache -s
+
+# Warning: untested and incomplete
+#
+#  build32:
+#    name: Ubuntu 32-bit
+#    runs-on: ubuntu-20.04
+#    container: ubuntu:latest
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        compiler: [gcc, clang]
+#        build_type: [Debug, Release]
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Install dependencies
+#        run: |
+#          dpkg --add-architecture i386
+#          apt update
+#          apt install -y cmake ninja-build clang:i386 llvm-dev:i386 libc-dev:i386
+#
+#      - name: Set environment
+#        run: |
+#          CFLAGS="$CFLAGS -m32"
+#          CXXFLAGS="$CXXFLAGS -m32"
+#
+#          if [[ "${{matrix.compiler}}" = "clang" ]]; then
+#            echo "CC=clang" >> $GITHUB_ENV
+#            echo "CXX=clang++" >> $GITHUB_ENV
+#
+#            # force coloured output
+#            echo "CFLAGS=$CFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+#            echo "CXXFLAGS=$CXXFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+#          else
+#            echo "CC=gcc" >> $GITHUB_ENV
+#            echo "CXX=g++" >> $GITHUB_ENV
+#
+#            # force coloured output
+#            echo "CFLAGS=$CFLAGS -fdiagnostics-color" >> $GITHUB_ENV
+#            echo "CXXFLAGS=$CXXFLAGS -fdiagnostics-color" >> $GITHUB_ENV
+#          fi
+#
+#      - name: Configure CMake project
+#        run: |
+#          cmake -Bbuild -S. \
+#                -GNinja \
+#                -DUSE_SANITIZERS=ON \
+#                -DCMAKE_BUILD_TYPE='${{matrix.build_type}}'
+#
+#      - name: Build
+#        run: ninja -C build
+#
+#      - name: Run tests
+#        # TODO: turn off the detection of leaks, we're working on it
+#        run: ASAN_OPTIONS=detect_leaks=0 ninja check -C build

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,66 @@
+---
+name: macOS CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [Debug, RelWithDebInfo]
+
+    runs-on: macos-latest
+    env:
+      # for colours in ninja
+      CLICOLOR_FORCE: 1
+
+    steps:
+      - name: Checkout DG
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: brew install ninja ccache
+
+      - name: Set environment
+        id: env
+        run: |
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
+
+          echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+
+          echo "::set-output name=timestamp::$(date -u +%Y-%m-%dT%H:%M:%S%z)"
+
+      - name: Set-up ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ${{matrix.os}}-${{matrix.build}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ${{matrix.os}}-${{matrix.build}}
+
+      - name: Configure CMake project
+        run: |
+          cmake -S. \
+                -B_build \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE:STRING=${{matrix.build}} \
+                -DUSE_SANITIZERS:BOOL=ON \
+                -DLLVM_DIR:PATH="$($(brew --prefix llvm)/bin/llvm-config --cmakedir)"
+        env:
+          # for coloured output
+          CFLAGS: -fcolor-diagnostics
+          CXXFLAGS: -fcolor-diagnostics
+
+      - name: Build
+        run: cmake --build _build
+
+      - name: Run tests
+        # TODO: turn off the detection of leaks, we're working on it
+        run: ASAN_OPTIONS=detect_leaks=0 cmake --build _build --target check
+
+      - name: ccache statistics
+        run: ccache -s

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -1,0 +1,112 @@
+---
+name: DG + SVF
+on: [push, pull_request]
+
+jobs:
+  Ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+
+    runs-on: ubuntu-20.04
+    env:
+      # for colours in ninja
+      CLICOLOR_FORCE: 1
+
+    steps:
+      - name: Checkout DG
+        uses: actions/checkout@v2
+
+      - name: Checkout SVF
+        uses: actions/checkout@v2
+        with:
+          repository: SVF-tools/SVF
+          path: svf
+
+      - name: Checkout SVF test-suite
+        uses: actions/checkout@v2
+        with:
+          repository: SVF-tools/Test-Suite
+          path: svf/Test-Suite
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ccache cmake ninja-build clang-10 llvm-10-dev \
+                           libz3-dev
+
+      - name: Set environment
+        id: env
+        run: |
+          if [[ "${{matrix.compiler}}" = "clang" ]]; then
+            echo "CC=clang-10" >> $GITHUB_ENV
+            echo "CXX=clang++-10" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fcolor-diagnostics" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+
+            # force coloured output
+            echo "CFLAGS=$CFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+            echo "CXXFLAGS=$CXXFLAGS -fdiagnostics-color=always" >> $GITHUB_ENV
+          fi
+
+          # set up ccache
+          sudo /usr/sbin/update-ccache-symlinks
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=400M" >> $GITHUB_ENV
+
+          echo "::set-output name=timestamp::$(date -u -Iseconds)"
+
+      - name: Set up ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ubuntu-20.04-svf-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ubuntu-20.04-svf-${{matrix.compiler}}
+
+      - name: Build SVF
+        run: |
+          # Prepare tests
+          (cd svf/Test-Suite && \
+           PATH="$(llvm-config-10 --bindir):$PATH" ./generate_bc.sh)
+
+          # Build directory name format is hard-coded in SVF tests...
+          cmake -Ssvf \
+                -Bsvf/RelWithDebInfo-build \
+                -GNinja \
+                -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+                -DLLVM_DIR:PATH="$(llvm-config-10 --cmakedir)"
+
+          cmake --build svf/RelWithDebInfo-build
+          (cd svf/RelWithDebInfo-build && \
+           PATH="$(llvm-config-10 --bindir):$PATH" \
+           ctest --progress --output-on-failure -j$(nproc))
+
+      - name: Configure CMake project
+        run: |
+          cmake -S. \
+                -B_build \
+                -GNinja \
+                -DUSE_SANITIZERS:BOOL=ON \
+                -DLLVM_DIR:PATH="$(llvm-config-10 --cmakedir)" \
+                -DSVF_DIR:PATH="$GITHUB_WORKSPACE/svf/RelWithDebInfo-build"
+
+      - name: Build
+        run: cmake --build _build
+
+      - name: Run tests
+        # TODO: turn off the detection of leaks, we're working on it
+        run: ASAN_OPTIONS=detect_leaks=0 cmake --build _build --target check
+
+      - name: ccache statistics
+        run: ccache -s

--- a/.github/workflows/xenial-llvm3.8/cmake.patch
+++ b/.github/workflows/xenial-llvm3.8/cmake.patch
@@ -1,0 +1,70 @@
+# Fix paths
+--- /usr/share/llvm-3.8/cmake/LLVMConfig.cmake  2020-11-23 10:06:50.536692742 +0000
++++ /usr/share/llvm-3.8/cmake/LLVMConfig.cmake  2020-11-23 10:10:22.746700044 +0000
+@@ -168,11 +168,11 @@
+
+ set(LLVM_LIBDIR_SUFFIX )
+
+-set(LLVM_INCLUDE_DIRS "${LLVM_INSTALL_PREFIX}/include")
+-set(LLVM_LIBRARY_DIRS "${LLVM_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}")
++set(LLVM_INCLUDE_DIRS "${LLVM_INSTALL_PREFIX}/include/llvm-3.8")
++set(LLVM_LIBRARY_DIRS "${LLVM_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/llvm-3.8/lib")
+ set(LLVM_DEFINITIONS "-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS")
+-set(LLVM_CMAKE_DIR "${LLVM_INSTALL_PREFIX}/share/llvm/cmake")
+-set(LLVM_TOOLS_BINARY_DIR "${LLVM_INSTALL_PREFIX}/bin")
++set(LLVM_CMAKE_DIR "${LLVM_INSTALL_PREFIX}/share/llvm-3.8/cmake")
++set(LLVM_TOOLS_BINARY_DIR "${LLVM_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/llvm-3.8/bin")
+
+ if(NOT TARGET LLVMSupport)
+   include("${LLVM_CMAKE_DIR}/LLVMExports.cmake")
+
+# Fix import prefix and remove polly as it's not a part of the LLVM package
+--- /usr/share/llvm-3.8/cmake/LLVMExports-relwithdebinfo.cmake  2020-11-23 10:10:46.280034183 +0000
++++ /usr/share/llvm-3.8/cmake/LLVMExports-relwithdebinfo.cmake  2020-11-23 10:13:04.810038954 +0000
+@@ -5,6 +5,9 @@
+ # Commands may need to know the format version.
+ set(CMAKE_IMPORT_FILE_VERSION 1)
+
++# Fix import prefix
++set(_IMPORT_PREFIX "/usr/lib${LLVM_LIB_PREFIX}/llvm-3.8/")
++
+ # Import target "LLVMSupport" for configuration "RelWithDebInfo"
+ set_property(TARGET LLVMSupport APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
+ set_target_properties(LLVMSupport PROPERTIES
+@@ -1164,36 +1167,6 @@
+ list(APPEND _IMPORT_CHECK_TARGETS LLVMLibDriver )
+ list(APPEND _IMPORT_CHECK_FILES_FOR_LLVMLibDriver "${_IMPORT_PREFIX}/lib/libLLVMLibDriver.a" )
+
+-# Import target "PollyISL" for configuration "RelWithDebInfo"
+-set_property(TARGET PollyISL APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
+-set_target_properties(PollyISL PROPERTIES
+-  IMPORTED_LINK_INTERFACE_LANGUAGES_RELWITHDEBINFO "C"
+-  IMPORTED_LOCATION_RELWITHDEBINFO "${_IMPORT_PREFIX}/lib/libPollyISL.a"
+-  )
+-
+-list(APPEND _IMPORT_CHECK_TARGETS PollyISL )
+-list(APPEND _IMPORT_CHECK_FILES_FOR_PollyISL "${_IMPORT_PREFIX}/lib/libPollyISL.a" )
+-
+-# Import target "Polly" for configuration "RelWithDebInfo"
+-set_property(TARGET Polly APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
+-set_target_properties(Polly PROPERTIES
+-  IMPORTED_LINK_INTERFACE_LANGUAGES_RELWITHDEBINFO "CXX"
+-  IMPORTED_LOCATION_RELWITHDEBINFO "${_IMPORT_PREFIX}/lib/libPolly.a"
+-  )
+-
+-list(APPEND _IMPORT_CHECK_TARGETS Polly )
+-list(APPEND _IMPORT_CHECK_FILES_FOR_Polly "${_IMPORT_PREFIX}/lib/libPolly.a" )
+-
+-# Import target "LLVMPolly" for configuration "RelWithDebInfo"
+-set_property(TARGET LLVMPolly APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
+-set_target_properties(LLVMPolly PROPERTIES
+-  IMPORTED_LOCATION_RELWITHDEBINFO "${_IMPORT_PREFIX}/lib/LLVMPolly.so"
+-  IMPORTED_NO_SONAME_RELWITHDEBINFO "TRUE"
+-  )
+-
+-list(APPEND _IMPORT_CHECK_TARGETS LLVMPolly )
+-list(APPEND _IMPORT_CHECK_FILES_FOR_LLVMPolly "${_IMPORT_PREFIX}/lib/LLVMPolly.so" )
+-
+ # Import target "LTO" for configuration "RelWithDebInfo"
+ set_property(TARGET LTO APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
+ set_target_properties(LTO PROPERTIES


### PR DESCRIPTION
This is a draft that adds support for GitHub Actions.

At first, I wanted to extend the current CI to more recent releases of LLVM and Ubuntu so that no commits would break compatibility with LLVM\Clang\GCC versions that were not covered before.

However, the total time (even when some jobs were skipped) was around 8 hours which is unacceptable (see https://travis-ci.org/github/lzaoral/dg/builds/744414197) and some jobs would even time-out as Travis has 50 minutes limit for a single job.

So I decided to try GitHub Actions instead. There is a higher limit on a single job (6 hours) and more jobs can run in parallel. While this PR is just a draft and some things still have to be implemented (see list below), the CI finishes in 20 minutes.

I have also decided to make `dg` compatible with systems that have more installations of LLVM  and to use `ninja` as a build-system as its output is less bloated when compared to `make`.

Only inconvenience is that Action failure e-mails can only be disabled per account in your notifications settings and not per Action/repository.

__TODO:__
1. force coloured output
2. FreeBSD?
