### PR TITLE
Refactor silencing pragmas

### DIFF
--- a/include/dg/llvm/CallGraph/CallGraph.h
+++ b/include/dg/llvm/CallGraph/CallGraph.h
@@ -4,23 +4,11 @@
 #include <vector>
 #include <memory>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/PSNode.h"
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"

--- a/include/dg/llvm/ControlDependence/ControlDependence.h
+++ b/include/dg/llvm/ControlDependence/ControlDependence.h
@@ -1,24 +1,12 @@
 #ifndef LLVM_DG_CDA_H_
 #define LLVM_DG_CDA_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/ControlDependence/LLVMControlDependenceAnalysisOptions.h"
 #include "dg/llvm/ControlDependence/LLVMControlDependenceAnalysisImpl.h"

--- a/include/dg/llvm/DataDependence/DataDependence.h
+++ b/include/dg/llvm/DataDependence/DataDependence.h
@@ -5,24 +5,12 @@
 #include <memory>
 #include <type_traits>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/DataDependence/DataDependence.h"
 

--- a/include/dg/llvm/Dominators/Dominators.h
+++ b/include/dg/llvm/Dominators/Dominators.h
@@ -1,23 +1,11 @@
 #ifndef _DG_DOMINATORS_H_
 #define _DG_DOMINATORS_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Dominators.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "BBlock.h"
 #include "analysis/DominanceFrontiers.h"

--- a/include/dg/llvm/LLVMDG2Dot.h
+++ b/include/dg/llvm/LLVMDG2Dot.h
@@ -9,26 +9,14 @@
 #include "dg/DG2Dot.h"
 #include "dg/llvm/LLVMNode.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR <= 4))
 #include "llvm/DebugInfo.h"     //DIScope
 #else
 #include "llvm/IR/DebugInfo.h"     //DIScope
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 using namespace dg;
 namespace dg {

--- a/include/dg/llvm/LLVMDGAssemblyAnnotationWriter.h
+++ b/include/dg/llvm/LLVMDGAssemblyAnnotationWriter.h
@@ -2,15 +2,8 @@
 #define _LLVM_DG_ASSEMBLY_ANNOTATION_WRITER_H_
 
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/FormattedStream.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -20,12 +13,7 @@
  #include <llvm/IR/AssemblyAnnotationWriter.h>
  #include <llvm/IR/Verifier.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"

--- a/include/dg/llvm/LLVMDependenceGraphBuilder.h
+++ b/include/dg/llvm/LLVMDependenceGraphBuilder.h
@@ -4,22 +4,10 @@
 #include <string>
 #include <ctime> // std::clock
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/PointerAnalysis/LLVMPointerAnalysisOptions.h"

--- a/include/dg/llvm/LLVMNode.h
+++ b/include/dg/llvm/LLVMNode.h
@@ -13,23 +13,11 @@
 #include <map>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Type.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/Node.h"
 

--- a/include/dg/llvm/LLVMSlicer.h
+++ b/include/dg/llvm/LLVMSlicer.h
@@ -1,15 +1,8 @@
 #ifndef LLVM_DG_SLICER_H_
 #define LLVM_DG_SLICER_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
@@ -23,12 +16,7 @@
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/Slicing.h"
 #include "dg/llvm/LLVMDependenceGraph.h"

--- a/include/dg/llvm/PointerAnalysis/DGPointerAnalysis.h
+++ b/include/dg/llvm/PointerAnalysis/DGPointerAnalysis.h
@@ -1,24 +1,12 @@
 #ifndef _LLVM_DG_POINTS_TO_ANALYSIS_H_
 #define _LLVM_DG_POINTS_TO_ANALYSIS_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/analysis/PointsTo/Pointer.h"
 #include "dg/analysis/PointsTo/PointerGraph.h"

--- a/include/dg/llvm/PointerAnalysis/LLVMPointsToSet.h
+++ b/include/dg/llvm/PointerAnalysis/LLVMPointsToSet.h
@@ -1,22 +1,10 @@
 #ifndef _LLVM_DG_POINTS_TO_SET_H_
 #define _LLVM_DG_POINTS_TO_SET_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/PointsToSet.h"
 

--- a/include/dg/llvm/PointerAnalysis/PointerAnalysis.h
+++ b/include/dg/llvm/PointerAnalysis/PointerAnalysis.h
@@ -1,24 +1,12 @@
 #ifndef _LLVM_DG_POINTS_TO_ANALYSIS_H_
 #define _LLVM_DG_POINTS_TO_ANALYSIS_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/Pointer.h"
 #include "dg/PointerAnalysis/PointerGraph.h"

--- a/include/dg/llvm/PointerAnalysis/PointerGraph.h
+++ b/include/dg/llvm/PointerAnalysis/PointerGraph.h
@@ -3,27 +3,15 @@
 
 #include <unordered_map>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/LLVMPointerAnalysisOptions.h"
 

--- a/include/dg/llvm/PointerAnalysis/SVFPointerAnalysis.h
+++ b/include/dg/llvm/PointerAnalysis/SVFPointerAnalysis.h
@@ -8,26 +8,17 @@
 #if (__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreorder"
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wignored-qualifiers"
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreorder"
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
@@ -40,18 +31,9 @@
 #include "SVF-FE/PAGBuilder.h" // PAGBuilder
 
 #if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#pragma clang diagnostic pop // ignore -Wreorder
-#pragma clang diagnostic pop // ignore -ignored-qualifiers
-#pragma clang diagnostic pop // ignore -Woverloaded-virtual
-#pragma clang diagnostic pop // ignore -Wunused-variable
+#pragma clang diagnostic pop
 #else
 #pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop // ignore -Wunused-but-set-variable
 #endif
 
 #include "dg/PointerAnalysis/Pointer.h"

--- a/include/dg/llvm/SystemDependenceGraph/SDG2Dot.h
+++ b/include/dg/llvm/SystemDependenceGraph/SDG2Dot.h
@@ -1,15 +1,8 @@
 #ifndef DG_LLVM_SDG2DOT_H_
 #define DG_LLVM_SDG2DOT_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include "llvm/IR/Instructions.h"
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR <= 4))
@@ -17,12 +10,7 @@
 #else
 #include "llvm/IR/DebugInfo.h"     //DIScope
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <iostream>
 #include <sstream>

--- a/include/dg/llvm/SystemDependenceGraph/SystemDependenceGraphBuilder.h
+++ b/include/dg/llvm/SystemDependenceGraph/SystemDependenceGraphBuilder.h
@@ -4,22 +4,10 @@
 #include <string>
 #include <ctime> // std::clock
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/PointerAnalysis/LLVMPointerAnalysisOptions.h"

--- a/include/dg/llvm/ThreadRegions/ControlFlowGraph.h
+++ b/include/dg/llvm/ThreadRegions/ControlFlowGraph.h
@@ -4,22 +4,10 @@
 #include <memory>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instructions.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 namespace dg {
     class DGLLVMPointerAnalysis;

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -1,27 +1,15 @@
 #ifndef DG_LLVM_VALUE_RELATION_RELATIONS_ANALYZER_HPP_
 #define DG_LLVM_VALUE_RELATION_RELATIONS_ANALYZER_HPP_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/CFG.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <algorithm>
 #include <string>

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -1,26 +1,14 @@
 #ifndef DG_LLVM_VALUE_RELATION_STRUCTURE_ANALYZER_HPP_
 #define DG_LLVM_VALUE_RELATION_STRUCTURE_ANALYZER_HPP_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <algorithm>
 

--- a/include/dg/util/SilenceLLVMWarnings.h
+++ b/include/dg/util/SilenceLLVMWarnings.h
@@ -1,0 +1,35 @@
+#ifndef DG_SILENCE_LLVM_WARNINGS_H
+#define DG_SILENCE_LLVM_WARNINGS_H
+
+// Helper macros to ignore unrelated warnings in LLVM libraries
+
+#ifndef SILENCE_LLVM_WARNINGS_PUSH
+#if defined(_MSC_VER)
+#define SILENCE_LLVM_WARNINGS_PUSH                          \
+_Pragma("warning(push)");
+// TODO
+#elif defined(__clang__)
+#define SILENCE_LLVM_WARNINGS_PUSH                          \
+_Pragma("clang diagnostic push");                           \
+_Pragma("clang diagnostic ignored \"-Wunused-parameter\"");
+#else // GCC
+#define SILENCE_LLVM_WARNINGS_PUSH                          \
+_Pragma("GCC diagnostic push");                             \
+_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"");
+#endif
+#endif
+
+#ifndef SILENCE_LLVM_WARNINGS_POP
+#if defined(_MSC_VER)
+#define SILENCE_LLVM_WARNINGS_POP \
+_Pragma("warning(pop)");
+#elif defined(__clang__)
+#define SILENCE_LLVM_WARNINGS_POP \
+_Pragma("clang diagnostic pop");
+#else // GCC
+#define SILENCE_LLVM_WARNINGS_POP \
+_Pragma("GCC diagnostic pop");
+#endif
+#endif
+
+#endif // DG_SILENCE_LLVM_WARNINGS_H

--- a/lib/llvm/ControlDependence/InterproceduralCD.cpp
+++ b/lib/llvm/ControlDependence/InterproceduralCD.cpp
@@ -1,21 +1,10 @@
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/CFG.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/util/debug.h"
 #include "llvm/ControlDependence/InterproceduralCD.h"

--- a/lib/llvm/ControlDependence/SCD.cpp
+++ b/lib/llvm/ControlDependence/SCD.cpp
@@ -1,24 +1,12 @@
 #include "SCD.h"
 
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/Analysis/DominanceFrontier.h>
 #include <llvm/Analysis/PostDominators.h>
 //#include "llvm/Analysis/IteratedDominanceFrontier.h"
-
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/ADT/Queue.h"
 #include "dg/util/debug.h"

--- a/lib/llvm/ControlDependence/SCD.h
+++ b/lib/llvm/ControlDependence/SCD.h
@@ -1,21 +1,10 @@
 #ifndef DG_LLVM_SCD_H_
 #define DG_LLVM_SCD_H_
 
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/ControlDependence/ControlDependence.h"
 #include "dg/util/debug.h"

--- a/lib/llvm/ControlDependence/legacy/Block.cpp
+++ b/lib/llvm/ControlDependence/legacy/Block.cpp
@@ -3,24 +3,12 @@
 
 #include <sstream>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Function.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 namespace dg {
 namespace llvmdg {

--- a/lib/llvm/ControlDependence/legacy/GraphBuilder.cpp
+++ b/lib/llvm/ControlDependence/legacy/GraphBuilder.cpp
@@ -1,23 +1,11 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/CFG.h>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Pass.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "llvm/ForkJoin/ForkJoin.h"
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"

--- a/lib/llvm/ControlDependence/legacy/NTSCD.h
+++ b/lib/llvm/ControlDependence/legacy/NTSCD.h
@@ -1,21 +1,10 @@
 #ifndef DG_LEGACY_LLVM_NTSCD_H_
 #define DG_LEGACY_LLVM_NTSCD_H_
 
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/ControlDependence/ControlDependence.h"
 #include "GraphBuilder.h"

--- a/lib/llvm/DataDependenceAnalysis/LLVMDataDependenceAnalysis.cpp
+++ b/lib/llvm/DataDependenceAnalysis/LLVMDataDependenceAnalysis.cpp
@@ -1,19 +1,7 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/GlobalVariable.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/DataDependence/DataDependence.h"
 #include "llvm/ReadWriteGraph/LLVMReadWriteGraphBuilder.h"

--- a/lib/llvm/DefUse/DefUse.cpp
+++ b/lib/llvm/DefUse/DefUse.cpp
@@ -1,14 +1,7 @@
 #include <map>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
@@ -18,12 +11,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/DFS.h"
 

--- a/lib/llvm/DefUse/DefUse.h
+++ b/lib/llvm/DefUse/DefUse.h
@@ -3,24 +3,12 @@
 
 #include <vector>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/DataLayout.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/legacy/DataFlowAnalysis.h"
 #include "dg/llvm/DataDependence/DataDependence.h"

--- a/lib/llvm/Dominators/PostDominators.cpp
+++ b/lib/llvm/Dominators/PostDominators.cpp
@@ -1,20 +1,8 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Function.h>
 #include <llvm/Analysis/PostDominators.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/BFS.h"
 #include "dg/Dominators/PostDominanceFrontiers.h"

--- a/lib/llvm/GraphBuilder.h
+++ b/lib/llvm/GraphBuilder.h
@@ -1,25 +1,13 @@
 #ifndef DG_GRAPHBUILDER_H_
 #define DG_GRAPHBUILDER_H_
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/CFG.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/CallGraph/CallGraph.h"
 #include "dg/ADT/SetQueue.h"

--- a/lib/llvm/LLVMDGVerifier.cpp
+++ b/lib/llvm/LLVMDGVerifier.cpp
@@ -1,24 +1,12 @@
 #include <cstdio>
 #include <cstdarg>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Function.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/LLVMNode.h"

--- a/lib/llvm/LLVMDependenceGraph.cpp
+++ b/lib/llvm/LLVMDependenceGraph.cpp
@@ -10,15 +10,8 @@
 #include <unordered_map>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -33,12 +26,7 @@
 #include <llvm/IR/Function.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/LLVMNode.h"

--- a/lib/llvm/LLVMNode.cpp
+++ b/lib/llvm/LLVMNode.cpp
@@ -6,15 +6,8 @@
  #error "Need CFG enabled for building LLVM Dependence Graph"
 #endif
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Value.h>
@@ -22,12 +15,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/Support/raw_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMNode.h"
 #include "dg/llvm/LLVMDependenceGraph.h"

--- a/lib/llvm/PointerAnalysis/Block.cpp
+++ b/lib/llvm/PointerAnalysis/Block.cpp
@@ -1,12 +1,5 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -18,12 +11,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 

--- a/lib/llvm/PointerAnalysis/Globals.cpp
+++ b/lib/llvm/PointerAnalysis/Globals.cpp
@@ -1,15 +1,8 @@
 #include <cassert>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -27,12 +20,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 

--- a/lib/llvm/PointerAnalysis/Interprocedural.cpp
+++ b/lib/llvm/PointerAnalysis/Interprocedural.cpp
@@ -1,12 +1,5 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -18,12 +11,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 

--- a/lib/llvm/PointerAnalysis/PointerAnalysis.cpp
+++ b/lib/llvm/PointerAnalysis/PointerAnalysis.cpp
@@ -1,19 +1,7 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instruction.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"
 #include "llvm/llvm-utils.h"

--- a/lib/llvm/PointerAnalysis/PointerGraph.cpp
+++ b/lib/llvm/PointerAnalysis/PointerGraph.cpp
@@ -1,15 +1,8 @@
 #include <cassert>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -29,12 +22,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 
 #include <llvm/IR/Dominators.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/PointerGraph.h"
 #include "dg/PointerAnalysis/PointerGraphOptimizations.h"

--- a/lib/llvm/PointerAnalysis/PointerGraphValidator.cpp
+++ b/lib/llvm/PointerAnalysis/PointerGraphValidator.cpp
@@ -1,20 +1,8 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Type.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "llvm/PointerAnalysis/PointerGraphValidator.h"
 

--- a/lib/llvm/PointerAnalysis/Structure.cpp
+++ b/lib/llvm/PointerAnalysis/Structure.cpp
@@ -1,15 +1,8 @@
 #include <cassert>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -27,12 +20,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 #include "dg/util/debug.h"

--- a/lib/llvm/PointerAnalysis/Threads.cpp
+++ b/lib/llvm/PointerAnalysis/Threads.cpp
@@ -1,15 +1,8 @@
 #include <cassert>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -29,12 +22,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 
 #include <llvm/IR/Dominators.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/PointerGraph.h"
 #include "dg/PointerAnalysis/PointerGraphOptimizations.h"

--- a/lib/llvm/ReadWriteGraph/Calls.cpp
+++ b/lib/llvm/ReadWriteGraph/Calls.cpp
@@ -1,15 +1,8 @@
 #include <vector>
 #include <cassert>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -19,12 +12,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 

--- a/lib/llvm/ReadWriteGraph/Instructions.cpp
+++ b/lib/llvm/ReadWriteGraph/Instructions.cpp
@@ -1,15 +1,8 @@
 #include <vector>
 #include <cassert>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -19,12 +12,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 //#include "dg/llvm/PointerAnalysis/PointerGraph.h"
 //#include "llvm/ForkJoin/ForkJoin.h"

--- a/lib/llvm/ReadWriteGraph/LLVMReadWriteGraphBuilder.cpp
+++ b/lib/llvm/ReadWriteGraph/LLVMReadWriteGraphBuilder.cpp
@@ -1,15 +1,8 @@
 #include <set>
 #include <cassert>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
  #include <llvm/Support/CFG.h>
@@ -28,12 +21,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 
 #include <llvm/IR/Dominators.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerGraph.h"
 #include "dg/ADT/Queue.h"

--- a/lib/llvm/ReadWriteGraph/LLVMReadWriteGraphBuilder.h
+++ b/lib/llvm/ReadWriteGraph/LLVMReadWriteGraphBuilder.h
@@ -5,25 +5,13 @@
 #include <set>
 #include <memory>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/CFG.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/ReadWriteGraph/ReadWriteGraph.h"
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"

--- a/lib/llvm/ThreadRegions/Graphs/CriticalSectionsBuilder.cpp
+++ b/lib/llvm/ThreadRegions/Graphs/CriticalSectionsBuilder.cpp
@@ -1,22 +1,10 @@
 #include "CriticalSectionsBuilder.h"
 #include "llvm/ThreadRegions/Nodes/Nodes.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instructions.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 
 

--- a/lib/llvm/ThreadRegions/Nodes/JoinNode.cpp
+++ b/lib/llvm/ThreadRegions/Nodes/JoinNode.cpp
@@ -2,22 +2,10 @@
 #include "ExitNode.h"
 #include "ForkNode.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Instructions.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 JoinNode::JoinNode(const llvm::Instruction *value, const llvm::CallInst *callInst)
     :Node(NodeType::JOIN, value, callInst){}

--- a/lib/llvm/ThreadRegions/Nodes/Node.cpp
+++ b/lib/llvm/ThreadRegions/Nodes/Node.cpp
@@ -1,20 +1,8 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/IR/Instructions.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <iostream>
 #include <sstream>

--- a/tests/thread-regions-test.cpp
+++ b/tests/thread-regions-test.cpp
@@ -8,15 +8,8 @@
 #include "../lib/llvm/ThreadRegions/Graphs/GraphBuilder.h"
 #include "../lib/llvm/ThreadRegions/Nodes/Nodes.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/LLVMContext.h>
@@ -24,12 +17,7 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <memory>
 #include <queue>

--- a/tools/include/dg/tools/llvm-slicer-opts.h
+++ b/tools/include/dg/tools/llvm-slicer-opts.h
@@ -4,22 +4,10 @@
 #include <vector>
 #include <set>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/CommandLine.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraphBuilder.h"
 

--- a/tools/include/dg/tools/llvm-slicer-utils.h
+++ b/tools/include/dg/tools/llvm-slicer-utils.h
@@ -3,24 +3,13 @@
 
 #include <functional>
 
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/ADT/StringRef.h>
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR <= 7
 #include <llvm/IR/InstIterator.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 std::vector<std::string> splitList(const std::string& opt, char sep = ',');
 

--- a/tools/include/dg/tools/llvm-slicer.h
+++ b/tools/include/dg/tools/llvm-slicer.h
@@ -4,15 +4,8 @@
 #include <ctime>
 #include <fstream>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_os_ostream.h>
 
@@ -22,12 +15,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/LLVMDependenceGraphBuilder.h"

--- a/tools/llvm-cda-bench.cpp
+++ b/tools/llvm-cda-bench.cpp
@@ -16,15 +16,8 @@
 #include "dg/tools/llvm-slicer-opts.h"
 #include "dg/tools/llvm-slicer-utils.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -43,12 +36,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/IR/InstIterator.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #ifdef HAVE_SVF
 #include "dg/llvm/PointerAnalysis/SVFPointerAnalysis.h"

--- a/tools/llvm-cda-dump.cpp
+++ b/tools/llvm-cda-dump.cpp
@@ -20,15 +20,8 @@
 #include "dg/tools/llvm-slicer-opts.h"
 #include "dg/tools/llvm-slicer-utils.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -47,12 +40,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/IR/InstIterator.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #ifdef HAVE_SVF
 #include "dg/llvm/PointerAnalysis/SVFPointerAnalysis.h"

--- a/tools/llvm-cda-stress.cpp
+++ b/tools/llvm-cda-stress.cpp
@@ -3,22 +3,10 @@
 #include <ctime>
 #include <random>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/CommandLine.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/tools/llvm-slicer-opts.h"
 

--- a/tools/llvm-cg-dump.cpp
+++ b/tools/llvm-cg-dump.cpp
@@ -19,15 +19,8 @@
 #include "dg/tools/llvm-slicer-opts.h"
 #include "dg/tools/llvm-slicer-utils.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -46,12 +39,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/IR/InstIterator.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #ifdef HAVE_SVF
 #include "dg/llvm/PointerAnalysis/SVFPointerAnalysis.h"

--- a/tools/llvm-dda-dump.cpp
+++ b/tools/llvm-dda-dump.cpp
@@ -7,15 +7,8 @@
 #include <cinttypes>
 #include <cstdio>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -29,12 +22,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/PointerAnalysis/PointerAnalysisFI.h"
 #include "dg/PointerAnalysis/PointerAnalysisFS.h"

--- a/tools/llvm-dg-dump.cpp
+++ b/tools/llvm-dg-dump.cpp
@@ -11,15 +11,8 @@
 #include <cassert>
 #include <cstdio>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Instructions.h>
@@ -33,12 +26,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/LLVMDependenceGraphBuilder.h"

--- a/tools/llvm-ntscd-dump.cpp
+++ b/tools/llvm-ntscd-dump.cpp
@@ -4,26 +4,14 @@
 #include "../lib/llvm/ControlDependence/legacy/GraphBuilder.h"
 #include "../lib/llvm/ControlDependence/legacy/NTSCD.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/CommandLine.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <fstream>
 

--- a/tools/llvm-pta-ben.cpp
+++ b/tools/llvm-pta-ben.cpp
@@ -12,15 +12,8 @@
 #include <cstdio>
 #include <cstdlib>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -33,12 +26,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"
 #include "dg/PointerAnalysis/PointerAnalysisFI.h"

--- a/tools/llvm-pta-compare.cpp
+++ b/tools/llvm-pta-compare.cpp
@@ -8,15 +8,8 @@
 #include <fstream>
 #include <string>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -32,12 +25,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"
 

--- a/tools/llvm-pta-dump.cpp
+++ b/tools/llvm-pta-dump.cpp
@@ -13,15 +13,8 @@
 #include <cstdio>
 #include <cstdlib>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -37,12 +30,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/PointerAnalysis/PointerAnalysis.h"
 #include "dg/PointerAnalysis/Pointer.h"

--- a/tools/llvm-sdg-dump.cpp
+++ b/tools/llvm-sdg-dump.cpp
@@ -19,15 +19,8 @@
 #include "dg/tools/llvm-slicer-opts.h"
 #include "dg/tools/llvm-slicer-utils.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -46,12 +39,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/IR/InstIterator.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/llvm/SystemDependenceGraph/SDG2Dot.h"
 #include "dg/llvm/SystemDependenceGraph/AnnotationWriter.h"

--- a/tools/llvm-slicer-crit.cpp
+++ b/tools/llvm-slicer-crit.cpp
@@ -13,15 +13,8 @@
 #error "Unsupported version of LLVM"
 #endif
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/CFG.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/InstIterator.h>
@@ -32,12 +25,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Value.h>
 #include <llvm/Support/raw_os_ostream.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/tools/llvm-slicer-utils.h"
 #include "dg/llvm/LLVMNode.h"

--- a/tools/llvm-slicer-metadata.cpp
+++ b/tools/llvm-slicer-metadata.cpp
@@ -1,23 +1,11 @@
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/InstIterator.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/DebugInfoMetadata.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/tools/llvm-slicer-utils.h"
 

--- a/tools/llvm-slicer-opts.cpp
+++ b/tools/llvm-slicer-opts.cpp
@@ -5,22 +5,10 @@
 #include "dg/llvm/DataDependence/LLVMDataDependenceAnalysisOptions.h"
 #include "dg/llvm/ControlDependence/LLVMControlDependenceAnalysisOptions.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Support/CommandLine.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/tools/llvm-slicer.h"
 #include "dg/tools/llvm-slicer-utils.h"

--- a/tools/llvm-slicer.cpp
+++ b/tools/llvm-slicer.cpp
@@ -20,15 +20,8 @@
 #include "dg/tools/llvm-slicer-opts.h"
 #include "dg/tools/llvm-slicer-utils.h"
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR <= 7
 #include <llvm/IR/LLVMContext.h>
 #endif
@@ -40,12 +33,7 @@
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/IR/InstIterator.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include "dg/ADT/Queue.h"
 #include "dg/util/debug.h"

--- a/tools/llvm-thread-regions-dump.cpp
+++ b/tools/llvm-thread-regions-dump.cpp
@@ -1,11 +1,5 @@
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -19,12 +13,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #include <iostream>
 #include <fstream>

--- a/tools/llvm-to-source.cpp
+++ b/tools/llvm-to-source.cpp
@@ -10,15 +10,8 @@
 #error "This code needs LLVM enabled"
 #endif
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/Config/llvm-config.h>
 
 #if ((LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR < 5))
@@ -32,12 +25,7 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/IRReader/IRReader.h>
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 using namespace llvm;
 

--- a/tools/llvm-vr-dump.cpp
+++ b/tools/llvm-vr-dump.cpp
@@ -10,15 +10,8 @@
 #include <cassert>
 #include <cstdio>
 
-// ignore unused parameters in LLVM libraries
-#if (__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+#include <dg/util/SilenceLLVMWarnings.h>
+SILENCE_LLVM_WARNINGS_PUSH
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Instructions.h>
@@ -33,12 +26,7 @@
 #else
 #include <llvm/Bitcode/ReaderWriter.h>
 #endif
-
-#if (__clang__)
-#pragma clang diagnostic pop // ignore -Wunused-parameter
-#else
-#pragma GCC diagnostic pop
-#endif
+SILENCE_LLVM_WARNINGS_POP
 
 #undef NDEBUG // we need dump methods
 #include "dg/llvm/ValueRelations/GraphBuilder.h"


### PR DESCRIPTION
- build: Factor out code to silence LLVM header warnings
- svf: Simplify code to silence warnings in SFV headers 