### PR TITLE
CI: Use the latest stable release of SVF

### DIFF
--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout SVF
         uses: actions/checkout@v2
         with:
+          ref: SVF-2.1
           repository: SVF-tools/SVF
           path: svf
 


### PR DESCRIPTION
It is less risky than using the master branch.