### PR TITLE
Add missing headers

### DIFF
--- a/include/dg/AnalysisOptions.h
+++ b/include/dg/AnalysisOptions.h
@@ -1,9 +1,11 @@
 #ifndef DG_ANALYSIS_OPTIONS_H_
 #define DG_ANALYSIS_OPTIONS_H_
 
-#include "Offset.h"
+#include <cassert>
 #include <map>
 #include <string>
+
+#include "Offset.h"
 
 namespace dg {
 

--- a/include/dg/DataDependence/DataDependenceAnalysisOptions.h
+++ b/include/dg/DataDependence/DataDependenceAnalysisOptions.h
@@ -1,6 +1,7 @@
 #ifndef DG_DATA_DEPENDENCE_ANALYSIS_OPTIONS_H_
 #define DG_DATA_DEPENDENCE_ANALYSIS_OPTIONS_H_
 
+#include <cassert>
 #include <map>
 
 #include "dg/AnalysisOptions.h"

--- a/include/dg/llvm/LLVMDG2Dot.h
+++ b/include/dg/llvm/LLVMDG2Dot.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "dg/DG2Dot.h"
+#include "dg/llvm/LLVMDependenceGraph.h"
 #include "dg/llvm/LLVMNode.h"
 
 #include <dg/util/SilenceLLVMWarnings.h>


### PR DESCRIPTION
clang-format removed some headers that were used
transitively in included files which is completely ok
apart from that it broke compilation.

This patch fixes the CI.