### PR TITLE
CI: fix SVF job

### DIFF
--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Checkout SVF test-suite
         uses: actions/checkout@v2
         with:
+          # last ref before SVF-2.2 release
+          ref: 72c679a49b943abb229fcb1844f68dff9cc7d522
           repository: SVF-tools/Test-Suite
           path: svf/Test-Suite
 


### PR DESCRIPTION
SVF and SVF Test-suite are separate repositories.  Therefore, we started
to run tests that were written for development version of SVF and not
for the latest release.