### PR TITLE
Add missing SVF initialization step

### DIFF
--- a/include/dg/llvm/PointerAnalysis/SVFPointerAnalysis.h
+++ b/include/dg/llvm/PointerAnalysis/SVFPointerAnalysis.h
@@ -166,6 +166,7 @@ class SVFPointerAnalysis : public LLVMPointerAnalysis {
         _svfModule =
                 moduleset->buildSVFModule(*const_cast<llvm::Module *>(_module));
         assert(_svfModule && "Failed building SVF module");
+        _svfModule->buildSymbolTableInfo();
 
         PAGBuilder builder;
         PAG *pag = builder.build(_svfModule);


### PR DESCRIPTION
Commit c3f2db (https://github.com/SVF-tools/SVF/commit/c3f2db1a4f2d1ebfd57aab51d6eeb3ff0148d4b8) breaks the compatiability. The missing init step comes from https://github.com/SVF-tools/SVF/blob/25e04bd4e0180d11d36021e5b2eed466739ce2d0/tools/Example/svf-ex.cpp#L161.