### PR TITLE
VR: extend to verify some cstr benchmarks

### DIFF
--- a/include/dg/ValueRelations/RelationsGraph.h
+++ b/include/dg/ValueRelations/RelationsGraph.h
@@ -365,6 +365,8 @@ class RelationsGraph {
         case Relations::NE:
             for (Relations::Type rel : {Relations::SLT, Relations::ULT,
                                         Relations::SGT, Relations::UGT}) {
+                if (areRelated(lt, rel, rt))
+                    return false;
                 if (areRelated(lt, Relations::getNonStrict(rel), rt,
                                &between)) {
                     unsetRelated(mLt, Relations::getNonStrict(rel), mRt);
@@ -377,6 +379,8 @@ class RelationsGraph {
         case Relations::ULT:
             if (areRelated(lt, Relations::getNonStrict(type), rt, &between))
                 unsetRelated(mLt, Relations::getNonStrict(type), mRt);
+            if (areRelated(lt, Relations::NE, rt, &between))
+                unsetRelated(mLt, Relations::NE, mRt);
             break; // jump after switch
 
         case Relations::SLE:

--- a/include/dg/ValueRelations/RelationsGraph.h
+++ b/include/dg/ValueRelations/RelationsGraph.h
@@ -482,6 +482,16 @@ class RelationsGraph {
         return bucket;
     }
 
+    void makeBorderBucket(const Bucket &b, size_t id) {
+        size_t currentId = getBorderId(b);
+        if (currentId == id)
+            return;
+
+        assert(getBorderB(id) == nullptr);
+        assert(getBorderId(b) == std::string::npos);
+        borderBuckets.emplace_back(id, b);
+    }
+
 #ifndef NDEBUG
     void dumpBorderBuckets(std::ostream &out = std::cerr) const {
         out << "[ ";

--- a/include/dg/ValueRelations/RelationsGraph.h
+++ b/include/dg/ValueRelations/RelationsGraph.h
@@ -141,12 +141,14 @@ class RelationsGraph {
     UniqueBucketSet buckets;
     size_t lastId = 0;
 
-    std::vector<std::pair<size_t, std::reference_wrapper<const Bucket>>> borderBuckets;
+    std::vector<std::pair<size_t, std::reference_wrapper<const Bucket>>>
+            borderBuckets;
 
     bool setEqual(Bucket &to, Bucket &from) {
         assert(to != from);
         if (getBorderId(from) != std::string::npos) {
-            assert(getBorderId(to) == std::string::npos); // cannot merge two border buckets
+            assert(getBorderId(to) ==
+                   std::string::npos); // cannot merge two border buckets
             for (auto &pair : borderBuckets) {
                 if (from == pair.second)
                     pair.second = to;
@@ -496,7 +498,8 @@ class RelationsGraph {
     void dumpBorderBuckets(std::ostream &out = std::cerr) const {
         out << "[ ";
         for (auto &pair : borderBuckets)
-            out << "(id " << pair.first << ", b " << pair.second.get().id << "), ";
+            out << "(id " << pair.first << ", b " << pair.second.get().id
+                << "), ";
         out << "]\n";
     }
 

--- a/include/dg/llvm/ValueRelations/GraphElements.h
+++ b/include/dg/llvm/ValueRelations/GraphElements.h
@@ -275,10 +275,10 @@ class VRCodeGraph {
 
       public:
         DFSIt() = default;
-        DFSIt(const llvm::Function &f, VRLocation *start, Dir d)
+        DFSIt(const llvm::Function &f, const VRLocation *start, Dir d)
                 : function(&f), dir(d) {
-            stack.emplace_back(start, 0, nullptr);
-            visit(start);
+            stack.emplace_back(const_cast<VRLocation*>(start), 0, nullptr);
+            visit(const_cast<VRLocation*>(start));
         }
 
         friend bool operator==(const DFSIt &lt, const DFSIt &rt) {
@@ -331,6 +331,8 @@ class VRCodeGraph {
             return false;
         }
         VREdge *getEdge() const { return std::get<2>(stack.back()); }
+
+        void skipSuccessors() { stack.pop_back(); }
     };
 
   public:
@@ -338,14 +340,15 @@ class VRCodeGraph {
     using LazyDFS = DFSIt<LazyVisit>;
 
     LazyDFS lazy_dfs_begin(const llvm::Function &f) const;
-    LazyDFS lazy_dfs_begin(const llvm::Function &f, VRLocation &start) const;
+    LazyDFS lazy_dfs_begin(const llvm::Function &f, const VRLocation &start) const;
     static LazyDFS lazy_dfs_end();
 
     SimpleDFS dfs_begin(const llvm::Function &f) const;
+    SimpleDFS dfs_begin(const llvm::Function &f, const VRLocation &start) const;
     static SimpleDFS dfs_end();
 
     static SimpleDFS backward_dfs_begin(const llvm::Function &f,
-                                        VRLocation &start);
+                                        const VRLocation &start);
     static SimpleDFS backward_dfs_end();
 
     /* ************ code graph iterator stuff ************ */

--- a/include/dg/llvm/ValueRelations/GraphElements.h
+++ b/include/dg/llvm/ValueRelations/GraphElements.h
@@ -143,6 +143,8 @@ struct VRLocation {
     std::vector<VREdge *> predecessors;
     std::vector<std::unique_ptr<VREdge>> successors;
 
+    std::vector<const VREdge *> loopEnds;
+
     VRLocation(unsigned _id) : id(_id) {}
 
     void connect(std::unique_ptr<VREdge> &&edge);

--- a/include/dg/llvm/ValueRelations/GraphElements.h
+++ b/include/dg/llvm/ValueRelations/GraphElements.h
@@ -144,6 +144,7 @@ struct VRLocation {
     std::vector<std::unique_ptr<VREdge>> successors;
 
     std::vector<const VREdge *> loopEnds;
+    const VRLocation *join = nullptr;
 
     VRLocation(unsigned _id) : id(_id) {}
 

--- a/include/dg/llvm/ValueRelations/GraphElements.h
+++ b/include/dg/llvm/ValueRelations/GraphElements.h
@@ -277,8 +277,8 @@ class VRCodeGraph {
         DFSIt() = default;
         DFSIt(const llvm::Function &f, const VRLocation *start, Dir d)
                 : function(&f), dir(d) {
-            stack.emplace_back(const_cast<VRLocation*>(start), 0, nullptr);
-            visit(const_cast<VRLocation*>(start));
+            stack.emplace_back(const_cast<VRLocation *>(start), 0, nullptr);
+            visit(const_cast<VRLocation *>(start));
         }
 
         friend bool operator==(const DFSIt &lt, const DFSIt &rt) {
@@ -340,7 +340,8 @@ class VRCodeGraph {
     using LazyDFS = DFSIt<LazyVisit>;
 
     LazyDFS lazy_dfs_begin(const llvm::Function &f) const;
-    LazyDFS lazy_dfs_begin(const llvm::Function &f, const VRLocation &start) const;
+    LazyDFS lazy_dfs_begin(const llvm::Function &f,
+                           const VRLocation &start) const;
     static LazyDFS lazy_dfs_end();
 
     SimpleDFS dfs_begin(const llvm::Function &f) const;

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -117,8 +117,7 @@ class RelationsAnalyzer {
             const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
     std::vector<const llvm::ICmpInst *> getEQICmp(const VRLocation &join);
-    void inferFromNonEquality(VRLocation &join, V from,
-                              const VectorSet<V> &initial, Shift s,
+    void inferFromNonEquality(VRLocation &join, V from, Shift s,
                               Handle placeholder);
     void
     inferShiftInLoop(const std::vector<const VRLocation *> &changeLocations,

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -59,7 +59,6 @@ class RelationsAnalyzer {
                        const llvm::BinaryOperator *operation);
     void solveCommutativity(ValueRelations &graph,
                             const llvm::BinaryOperator *operation);
-    V getAnyInitial(const VRLocation &join, V from) const;
     enum class Shift { INC, DEC, EQ, UNKNOWN };
     static Shift getShift(const llvm::BinaryOperator *op, V from);
     static Shift getShift(const llvm::GetElementPtrInst *op, V from);
@@ -105,6 +104,8 @@ class RelationsAnalyzer {
     static std::pair<C, Relations> getBoundOnPointedToValue(
             const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
+    static const llvm::ICmpInst *getEQICmp(const VRLocation &join);
+    void inferFromNonEquality(VRLocation& join, V from, const VectorSet<V>& initial, Shift s, Handle placeholder);
     void
     inferShiftInLoop(const std::vector<const VRLocation *> &changeLocations,
                      V from, ValueRelations &newGraph, Handle placeholder);

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -114,7 +114,8 @@ class RelationsAnalyzer {
         for (unsigned i = 1; i < changeLocations.size(); ++i) {
             const ValueRelations &graph = changeLocations[i]->relations;
             HandlePtr from = getCorrespondingByContent(graph, froms);
-            assert(from);
+            if (!from)
+                return Relations();
             assert(graph.hasLoad(*from));
             Handle loaded = graph.getPointedTo(*from);
 
@@ -189,6 +190,11 @@ class RelationsAnalyzer {
                                                Handle h);
     static HandlePtr getCorrespondingByContent(const ValueRelations &toRels,
                                                const VectorSet<V> &vals);
+
+    static HandlePtr getCorrespondingByFrom(const ValueRelations &toRels,
+                                            const ValueRelations &fromRels,
+                                            Handle h);
+
     static const llvm::AllocaInst *getOrigin(const ValueRelations &rels, V val);
 };
 

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -67,8 +67,6 @@ class RelationsAnalyzer {
                    V from) const;
     bool canShift(const ValueRelations &graph, V param, Relations::Type shift);
     void solveDifferent(ValueRelations &graph, const llvm::BinaryOperator *op);
-    std::vector<const VREdge *> possibleSources(const llvm::PHINode *phi,
-                                                bool bval) const;
     void inferFromNEPointers(ValueRelations &newGraph,
                              VRAssumeBool *assume) const;
 
@@ -109,7 +107,7 @@ class RelationsAnalyzer {
     static std::pair<C, Relations> getBoundOnPointedToValue(
             const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
-    static const llvm::ICmpInst *getEQICmp(const VRLocation &join);
+    std::vector<const llvm::ICmpInst *> getEQICmp(const VRLocation &join);
     void inferFromNonEquality(VRLocation &join, V from,
                               const VectorSet<V> &initial, Shift s,
                               Handle placeholder);

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -67,6 +67,8 @@ class RelationsAnalyzer {
                    V from) const;
     bool canShift(const ValueRelations &graph, V param, Relations::Type shift);
     void solveDifferent(ValueRelations &graph, const llvm::BinaryOperator *op);
+    void inferFromNEPointers(ValueRelations &newGraph,
+                             VRAssumeBool *assume) const;
 
     // ******************** gen from instruction ************************** //
     static void storeGen(ValueRelations &graph, const llvm::StoreInst *store);
@@ -105,7 +107,9 @@ class RelationsAnalyzer {
             const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
     static const llvm::ICmpInst *getEQICmp(const VRLocation &join);
-    void inferFromNonEquality(VRLocation& join, V from, const VectorSet<V>& initial, Shift s, Handle placeholder);
+    void inferFromNonEquality(VRLocation &join, V from,
+                              const VectorSet<V> &initial, Shift s,
+                              Handle placeholder);
     void
     inferShiftInLoop(const std::vector<const VRLocation *> &changeLocations,
                      V from, ValueRelations &newGraph, Handle placeholder);

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -61,11 +61,13 @@ class RelationsAnalyzer {
     void solveCommutativity(ValueRelations &graph,
                             const llvm::BinaryOperator *operation);
     enum class Shift { INC, DEC, EQ, UNKNOWN };
-    static Shift getShift(const llvm::BinaryOperator *op, V from);
-    static Shift getShift(const llvm::GetElementPtrInst *op, V from);
-    static Shift getShift(const llvm::Value *val, V from);
+    static Shift getShift(const llvm::BinaryOperator *op,
+                          const VectorSet<V> &froms);
+    static Shift getShift(const llvm::GetElementPtrInst *op,
+                          const VectorSet<V> &froms);
+    static Shift getShift(const llvm::Value *val, const VectorSet<V> &froms);
     Shift getShift(const std::vector<const VRLocation *> &changeLocations,
-                   V from) const;
+                   const VectorSet<V> &froms) const;
     bool canShift(const ValueRelations &graph, V param, Relations::Type shift);
     void solveDifferent(ValueRelations &graph, const llvm::BinaryOperator *op);
     void inferFromNEPointers(ValueRelations &newGraph,
@@ -103,32 +105,37 @@ class RelationsAnalyzer {
     static void inferFromPreds(VRLocation &location, Handle lt, Relations known,
                                Handle rt);
     static Relations
-    getCommonByPointedTo(V from,
+    getCommonByPointedTo(const VectorSet<V> &froms,
                          const std::vector<const VRLocation *> &changeRelations,
                          V val, Relations rels);
     std::vector<const VRLocation *>
-    getBranchChangeLocations(const VRLocation &join, V from) const;
+    getBranchChangeLocations(const VRLocation &join,
+                             const VectorSet<V> &froms) const;
     std::vector<const VRLocation *>
-    getLoopChangeLocations(const VRLocation &join, V form) const;
+    getLoopChangeLocations(const VRLocation &join,
+                           const VectorSet<V> &froms) const;
 
     // get target locations of changing instructions
-    std::vector<const VRLocation *> getChangeLocations(const VRLocation &join,
-                                                       V from);
+    std::vector<const VRLocation *>
+    getChangeLocations(const VRLocation &join, const VectorSet<V> &froms);
     static std::pair<C, Relations> getBoundOnPointedToValue(
-            const std::vector<const VRLocation *> &changeLocations, V from,
-            Relation rel);
+            const std::vector<const VRLocation *> &changeLocations,
+            const VectorSet<V> &froms, Relation rel);
     std::vector<const llvm::ICmpInst *> getEQICmp(const VRLocation &join);
-    void inferFromNonEquality(VRLocation &join, V from, Shift s,
-                              Handle placeholder);
+    void inferFromNonEquality(VRLocation &join, const VectorSet<V> &froms,
+                              Shift s, Handle placeholder);
     void
     inferShiftInLoop(const std::vector<const VRLocation *> &changeLocations,
-                     V from, ValueRelations &newGraph, Handle placeholder);
+                     const VectorSet<V> &froms, ValueRelations &newGraph,
+                     Handle placeholder);
     static void
-    relateBounds(const std::vector<const VRLocation *> &changeLocations, V from,
-                 ValueRelations &newGraph, Handle placeholder);
+    relateBounds(const std::vector<const VRLocation *> &changeLocations,
+                 const VectorSet<V> &froms, ValueRelations &newGraph,
+                 Handle placeholder);
     static void
-    relateValues(const std::vector<const VRLocation *> &changeLocations, V from,
-                 ValueRelations &newGraph, Handle placeholder);
+    relateValues(const std::vector<const VRLocation *> &changeLocations,
+                 const VectorSet<V> &froms, ValueRelations &newGraph,
+                 Handle placeholder);
 
     // **************************** merge ******************************* //
     static void mergeRelations(VRLocation &location);
@@ -165,6 +172,8 @@ class RelationsAnalyzer {
     static HandlePtr getCorrespondingByContent(const ValueRelations &toRels,
                                                const ValueRelations &fromRels,
                                                Handle h);
+    static HandlePtr getCorrespondingByContent(const ValueRelations &toRels,
+                                               const VectorSet<V> &vals);
     static const llvm::AllocaInst *getOrigin(const ValueRelations &rels, V val);
 };
 

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -23,6 +23,7 @@ namespace vr {
 
 class RelationsAnalyzer {
     using Handle = ValueRelations::Handle;
+    using HandlePtr = ValueRelations::HandlePtr;
     using HandleRef = ValueRelations::BRef;
     using Relation = Relations::Type;
     using V = ValueRelations::V;
@@ -154,6 +155,17 @@ class RelationsAnalyzer {
             : module(m), codeGraph(g), structure(sa) {}
 
     unsigned analyze(unsigned maxPass);
+
+    static std::vector<V> getFroms(const ValueRelations &rels, V val);
+    static HandlePtr getHandleFromFroms(const ValueRelations &rels,
+                                        const std::vector<V> &froms);
+    static HandlePtr getHandleFromFroms(const ValueRelations &toRels,
+                                        const ValueRelations &fromRels, V val);
+
+    static HandlePtr getCorrespondingByContent(const ValueRelations &toRels,
+                                               const ValueRelations &fromRels,
+                                               Handle h);
+    static const llvm::AllocaInst *getOrigin(const ValueRelations &rels, V val);
 };
 
 } // namespace vr

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -51,9 +51,6 @@ class RelationsAnalyzer {
     bool mayOverwrite(I inst, V address) const;
 
     // ************************ operation helpers ************************* //
-    static void solvesDiffOne(ValueRelations &graph, V param,
-                              const llvm::BinaryOperator *op,
-                              Relations::Type rel);
     static bool operandsEqual(ValueRelations &graph, I fst, I snd,
                               bool sameOrder);
     void solveByOperands(ValueRelations &graph,

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -59,6 +59,13 @@ class RelationsAnalyzer {
                        const llvm::BinaryOperator *operation);
     void solveCommutativity(ValueRelations &graph,
                             const llvm::BinaryOperator *operation);
+    V getAnyInitial(const VRLocation &join, V from) const;
+    enum class Shift { INC, DEC, EQ, UNKNOWN };
+    static Shift getShift(const llvm::BinaryOperator *op, V from);
+    static Shift getShift(const llvm::GetElementPtrInst *op, V from);
+    static Shift getShift(const llvm::Value *val, V from);
+    Shift getShift(const std::vector<const VRLocation *> &changeLocations,
+                   V from) const;
     bool canShift(const ValueRelations &graph, V param, Relations::Type shift);
     void solveDifferent(ValueRelations &graph, const llvm::BinaryOperator *op);
 
@@ -87,25 +94,20 @@ class RelationsAnalyzer {
     getCommonByPointedTo(V from,
                          const std::vector<const VRLocation *> &changeRelations,
                          V val, Relations rels);
-    static Relations
-    getCommonByPointedTo(V from,
-                         const std::vector<const VRLocation *> &changeLocations,
-                         V firstLoad, V prevVal);
     std::vector<const VRLocation *>
     getBranchChangeLocations(const VRLocation &join, V from) const;
-    std::pair<std::vector<const VRLocation *>, V>
+    std::vector<const VRLocation *>
     getLoopChangeLocations(const VRLocation &join, V form) const;
 
     // get target locations of changing instructions
-    std::pair<std::vector<const VRLocation *>, V>
-    getChangeLocations(const VRLocation &join, V from);
+    std::vector<const VRLocation *> getChangeLocations(const VRLocation &join,
+                                                       V from);
     static std::pair<C, Relations> getBoundOnPointedToValue(
             const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
-    static void
-    relateToFirstLoad(const std::vector<const VRLocation *> &changeLocations,
-                      V from, ValueRelations &newGraph, Handle placeholder,
-                      V firstLoad);
+    void
+    inferShiftInLoop(const std::vector<const VRLocation *> &changeLocations,
+                     V from, ValueRelations &newGraph, Handle placeholder);
     static void
     relateBounds(const std::vector<const VRLocation *> &changeLocations, V from,
                  ValueRelations &newGraph, Handle placeholder);

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -83,26 +83,35 @@ class RelationsAnalyzer {
                                Relations known, V rt);
     static void checkRelatesInAll(VRLocation &location, V lt, Relations known,
                                   V rt, std::set<V> &setEqual);
-    static Relations getCommonByPointedTo(
-            V from, const std::vector<const ValueRelations *> &changeRelations,
-            V val, Relations rels);
-    static Relations getCommonByPointedTo(
-            V from, const std::vector<const ValueRelations *> &changeRelations,
-            V firstLoad, V prevVal);
-    std::pair<std::vector<const ValueRelations *>, V>
-    getChangeRelations(V from, VRLocation &join);
+    static Relations
+    getCommonByPointedTo(V from,
+                         const std::vector<const VRLocation *> &changeRelations,
+                         V val, Relations rels);
+    static Relations
+    getCommonByPointedTo(V from,
+                         const std::vector<const VRLocation *> &changeLocations,
+                         V firstLoad, V prevVal);
+    std::vector<const VRLocation *>
+    getBranchChangeLocations(const VRLocation &join, V from) const;
+    std::pair<std::vector<const VRLocation *>, V>
+    getLoopChangeLocations(const VRLocation &join, V form) const;
+
+    // get target locations of changing instructions
+    std::pair<std::vector<const VRLocation *>, V>
+    getChangeLocations(const VRLocation &join, V from);
     static std::pair<C, Relations> getBoundOnPointedToValue(
-            const std::vector<const ValueRelations *> &changeRelations, V from,
+            const std::vector<const VRLocation *> &changeLocations, V from,
             Relation rel);
-    static void relateToFirstLoad(
-            const std::vector<const ValueRelations *> &changeRelations, V from,
-            ValueRelations &newGraph, Handle placeholder, V firstLoad);
     static void
-    relateBounds(const std::vector<const ValueRelations *> &changeRelations,
-                 V from, ValueRelations &newGraph, Handle placeholder);
+    relateToFirstLoad(const std::vector<const VRLocation *> &changeLocations,
+                      V from, ValueRelations &newGraph, Handle placeholder,
+                      V firstLoad);
     static void
-    relateValues(const std::vector<const ValueRelations *> &changeRelations,
-                 V from, ValueRelations &newGraph, Handle placeholder);
+    relateBounds(const std::vector<const VRLocation *> &changeLocations, V from,
+                 ValueRelations &newGraph, Handle placeholder);
+    static void
+    relateValues(const std::vector<const VRLocation *> &changeLocations, V from,
+                 ValueRelations &newGraph, Handle placeholder);
 
     // **************************** merge ******************************* //
     static void mergeRelations(VRLocation &location);

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -88,10 +88,19 @@ class RelationsAnalyzer {
                     VRAssumeBool *assume) const;
 
     // *********************** merge helpers **************************** //
-    static Relations getCommon(const VRLocation &location, V lt,
-                               Relations known, V rt);
-    static void checkRelatesInAll(VRLocation &location, V lt, Relations known,
-                                  V rt, std::set<V> &setEqual);
+    template <typename X, typename Y>
+    static Relations getCommon(const VRLocation &location, const X &lt,
+                               Relations known, const Y &rt) {
+        for (VREdge *predEdge : location.predecessors) {
+            const ValueRelations &predRels = predEdge->source->relations;
+            known &= predRels.between(lt, rt);
+            if (!known.any())
+                return Relations();
+        }
+        return known;
+    }
+    static void inferFromPreds(VRLocation &location, Handle lt, Relations known,
+                               Handle rt);
     static Relations
     getCommonByPointedTo(V from,
                          const std::vector<const VRLocation *> &changeRelations,

--- a/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/RelationsAnalyzer.h
@@ -67,6 +67,8 @@ class RelationsAnalyzer {
                    V from) const;
     bool canShift(const ValueRelations &graph, V param, Relations::Type shift);
     void solveDifferent(ValueRelations &graph, const llvm::BinaryOperator *op);
+    std::vector<const VREdge *> possibleSources(const llvm::PHINode *phi,
+                                                bool bval) const;
     void inferFromNEPointers(ValueRelations &newGraph,
                              VRAssumeBool *assume) const;
 
@@ -84,7 +86,8 @@ class RelationsAnalyzer {
     static Relation ICMPToRel(const llvm::ICmpInst *icmp, bool assumption);
     static bool processICMP(const ValueRelations &oldGraph,
                             ValueRelations &newGraph, VRAssumeBool *assume);
-    bool processPhi(ValueRelations &newGraph, VRAssumeBool *assume) const;
+    bool processPhi(const ValueRelations &oldGraph, ValueRelations &newGraph,
+                    VRAssumeBool *assume) const;
 
     // *********************** merge helpers **************************** //
     static Relations getCommon(const VRLocation &location, V lt,

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -148,8 +148,8 @@ class StructureAnalyzer {
     const std::vector<BorderValue> &
     getBorderValuesFor(const llvm::Function *func) const;
 
-    const llvm::Argument *getBorderArgumentFor(const llvm::Function *func,
-                                               size_t id) const;
+    const BorderValue &getBorderValueFor(const llvm::Function *func,
+                                         size_t id) const;
 
 #ifndef NDEBUG
     void dumpBorderValues(std::ostream &out = std::cerr) const;

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -148,8 +148,7 @@ class StructureAnalyzer {
     const std::vector<BorderValue> &
     getBorderValuesFor(const llvm::Function *func) const;
 
-    const BorderValue &getBorderValueFor(const llvm::Function *func,
-                                         size_t id) const;
+    BorderValue getBorderValueFor(const llvm::Function *func, size_t id) const;
 
 #ifndef NDEBUG
     void dumpBorderValues(std::ostream &out = std::cerr) const;

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -134,13 +134,26 @@ class StructureAnalyzer {
     const std::vector<Precondition> &
     getPreconditionsFor(const llvm::Function *func) const;
 
-    void addBorderValue(const llvm::Function *func, const llvm::Argument *from,
-                        const ValueRelations::Handle &h);
+    size_t addBorderValue(const llvm::Function *func, const llvm::Argument *from);
 
     bool hasBorderValues(const llvm::Function *func) const;
 
     const std::vector<BorderValue> &
     getBorderValuesFor(const llvm::Function *func) const;
+
+    const llvm::Argument *getBorderArgumentFor(const llvm::Function *func, size_t id) const;
+
+#ifndef NDEBUG
+    void dumpBorderValues(std::ostream &out = std::cerr) const {
+        out << "[ \n";
+        for (auto &foo : borderValues) {
+            out << "    " << foo.first->getName().str() << ": ";
+            for (auto &pair : foo.second)
+                out << "(from " << debug::getValName(pair.from) << ", id " << pair.id << "), ";
+        }
+        out << "\n]\n";
+    }
+#endif
 };
 
 } // namespace vr

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -147,19 +147,7 @@ class StructureAnalyzer {
                                                size_t id) const;
 
 #ifndef NDEBUG
-    void dumpBorderValues(std::ostream &out = std::cerr) const {
-        out << "[ \n";
-        for (auto &foo : borderValues) {
-            out << "    " << foo.first->getName().str() << ": ";
-            for (auto &bv : foo.second)
-                out << "("
-                    << "id " << bv.id << ", "
-                    << "from " << debug::getValName(bv.from) << ", "
-                    << "stored " << debug::getValName(bv.stored)
-                    << "), ";
-        }
-        out << "\n]\n";
-    }
+    void dumpBorderValues(std::ostream &out = std::cerr) const;
 #endif
 };
 

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -47,8 +47,8 @@ class StructureAnalyzer {
 
     void findLoops();
 
-    std::set<VREdge *> collectBackward(const llvm::Function &f,
-                                       VRLocation &from);
+    std::set<VRLocation *> collectBackward(const llvm::Function &f,
+                                           VRLocation &from);
 
     void initializeDefined();
 

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -56,11 +56,14 @@ struct CallRelation {
     VRLocation *callSite = nullptr;
 };
 
-/* arg is left of rel */
 struct Precondition {
-    const llvm::Value *arg;
+    const llvm::Argument *arg;
     Relations::Type rel;
     const llvm::Value *val;
+
+    Precondition(const llvm::Argument *a, Relations::Type r,
+                 const llvm::Value *v)
+            : arg(a), rel(r), val(v) {}
 };
 
 class StructureAnalyzer {
@@ -86,7 +89,8 @@ class StructureAnalyzer {
     std::map<const llvm::Function *, std::vector<CallRelation>>
             callRelationsMap;
 
-    std::map<const llvm::Function *, VectorSet<Precondition>> preconditionsMap;
+    std::map<const llvm::Function *, std::vector<Precondition>>
+            preconditionsMap;
 
     void categorizeEdges();
 
@@ -171,12 +175,12 @@ class StructureAnalyzer {
     const std::vector<CallRelation> &
     getCallRelationsFor(const llvm::Instruction *inst) const;
 
-    void addPrecondition(const llvm::Function *func, const llvm::Value *lt,
+    void addPrecondition(const llvm::Function *func, const llvm::Argument *lt,
                          Relations::Type rel, const llvm::Value *rt);
 
     bool hasPreconditions(const llvm::Function *func) const;
 
-    const VectorSet<Precondition> &
+    const std::vector<Precondition> &
     getPreconditionsFor(const llvm::Function *func) const;
 };
 

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -41,6 +41,7 @@ class StructureAnalyzer {
 
     std::map<const llvm::Function *, std::vector<Precondition>>
             preconditionsMap;
+    std::map<const llvm::Function *, std::vector<BorderValue>> borderValues;
 
     void categorizeEdges();
 
@@ -132,6 +133,14 @@ class StructureAnalyzer {
 
     const std::vector<Precondition> &
     getPreconditionsFor(const llvm::Function *func) const;
+
+    void addBorderValue(const llvm::Function *func, const llvm::Argument *from,
+                        const ValueRelations::Handle &h);
+
+    bool hasBorderValues(const llvm::Function *func) const;
+
+    const std::vector<BorderValue> &
+    getBorderValuesFor(const llvm::Function *func) const;
 };
 
 } // namespace vr

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -134,22 +134,29 @@ class StructureAnalyzer {
     const std::vector<Precondition> &
     getPreconditionsFor(const llvm::Function *func) const;
 
-    size_t addBorderValue(const llvm::Function *func, const llvm::Argument *from);
+    size_t addBorderValue(const llvm::Function *func,
+                          const llvm::Argument *from,
+                          const llvm::Value *stored);
 
     bool hasBorderValues(const llvm::Function *func) const;
 
     const std::vector<BorderValue> &
     getBorderValuesFor(const llvm::Function *func) const;
 
-    const llvm::Argument *getBorderArgumentFor(const llvm::Function *func, size_t id) const;
+    const llvm::Argument *getBorderArgumentFor(const llvm::Function *func,
+                                               size_t id) const;
 
 #ifndef NDEBUG
     void dumpBorderValues(std::ostream &out = std::cerr) const {
         out << "[ \n";
         for (auto &foo : borderValues) {
             out << "    " << foo.first->getName().str() << ": ";
-            for (auto &pair : foo.second)
-                out << "(from " << debug::getValName(pair.from) << ", id " << pair.id << "), ";
+            for (auto &bv : foo.second)
+                out << "("
+                    << "id " << bv.id << ", "
+                    << "from " << debug::getValName(bv.from) << ", "
+                    << "stored " << debug::getValName(bv.stored)
+                    << "), ";
         }
         out << "\n]\n";
     }

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -70,7 +70,8 @@ class StructureAnalyzer {
     // holds vector of instructions, which are processed on any path back to
     // given location is computed only for locations with more than one
     // predecessor
-    std::map<VRLocation *, std::vector<const llvm::Instruction *>> inloopValues;
+    std::map<const VRLocation *, std::vector<const llvm::Instruction *>>
+            inloopValues;
 
     // holds vector of values, which are defined at given location
     std::map<VRLocation *, std::set<const llvm::Value *>> defined;
@@ -153,7 +154,7 @@ class StructureAnalyzer {
 
     // assumes that location is valid loop start (join of tree and back edges)
     const std::vector<const llvm::Instruction *> &
-    getInloopValues(VRLocation &location) const {
+    getInloopValues(const VRLocation &location) const {
         return inloopValues.at(&location);
     }
 

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -107,6 +107,11 @@ class StructureAnalyzer {
 
     bool isDefined(VRLocation *loc, const llvm::Value *val) const;
 
+    std::vector<const VREdge *> possibleSources(const llvm::PHINode *phi,
+                                                bool bval) const;
+    std::vector<const llvm::ICmpInst *>
+    getRelevantConditions(const VRAssumeBool *assume) const;
+
     // assumes that location is valid loop start (join of tree and back edges)
     const std::vector<const llvm::Instruction *> &
     getInloopValues(const VRLocation &location) const {

--- a/include/dg/llvm/ValueRelations/StructureAnalyzer.h
+++ b/include/dg/llvm/ValueRelations/StructureAnalyzer.h
@@ -10,61 +10,11 @@
 #include <algorithm>
 
 #include "GraphElements.h"
+#include "StructureElements.h"
 #include "dg/AnalysisOptions.h"
 
 namespace dg {
 namespace vr {
-
-struct AllocatedSizeView {
-    const llvm::Value *elementCount = nullptr;
-    uint64_t elementSize = 0; // in bytes
-
-    AllocatedSizeView() = default;
-    AllocatedSizeView(const llvm::Value *count, uint64_t size)
-            : elementCount(count), elementSize(size) {}
-};
-
-class AllocatedArea {
-    const llvm::Value *ptr;
-    // used only if memory was allocated with realloc, as fallback when realloc
-    // fails
-    const llvm::Value *reallocatedPtr = nullptr;
-    AllocatedSizeView originalSizeView;
-
-  public:
-    static const llvm::Value *stripCasts(const llvm::Value *inst);
-
-    static uint64_t getBytes(const llvm::Type *type);
-
-    AllocatedArea(const llvm::AllocaInst *alloca);
-
-    AllocatedArea(const llvm::CallInst *call);
-
-    const llvm::Value *getPtr() const { return ptr; }
-    const llvm::Value *getReallocatedPtr() const { return reallocatedPtr; }
-
-    std::vector<AllocatedSizeView> getAllocatedSizeViews() const;
-
-#ifndef NDEBUG
-    void ddump() const;
-#endif
-};
-
-struct CallRelation {
-    std::vector<std::pair<const llvm::Argument *, const llvm::Value *>>
-            equalPairs;
-    VRLocation *callSite = nullptr;
-};
-
-struct Precondition {
-    const llvm::Argument *arg;
-    Relations::Type rel;
-    const llvm::Value *val;
-
-    Precondition(const llvm::Argument *a, Relations::Type r,
-                 const llvm::Value *v)
-            : arg(a), rel(r), val(v) {}
-};
 
 class StructureAnalyzer {
     const llvm::Module &module;

--- a/include/dg/llvm/ValueRelations/StructureElements.h
+++ b/include/dg/llvm/ValueRelations/StructureElements.h
@@ -59,6 +59,14 @@ struct Precondition {
             : arg(a), rel(r), val(v) {}
 };
 
+struct BorderValue {
+    const llvm::Argument *from;
+    ValueRelations::Handle handle;
+
+    BorderValue(const llvm::Argument *f, ValueRelations::Handle h)
+            : from(f), handle(h) {}
+};
+
 } // namespace vr
 } // namespace dg
 

--- a/include/dg/llvm/ValueRelations/StructureElements.h
+++ b/include/dg/llvm/ValueRelations/StructureElements.h
@@ -61,10 +61,10 @@ struct Precondition {
 
 struct BorderValue {
     const llvm::Argument *from;
-    ValueRelations::Handle handle;
+    size_t id;
 
-    BorderValue(const llvm::Argument *f, ValueRelations::Handle h)
-            : from(f), handle(h) {}
+    BorderValue(const llvm::Argument *f, size_t i)
+            : from(f), id(i) {}
 };
 
 } // namespace vr

--- a/include/dg/llvm/ValueRelations/StructureElements.h
+++ b/include/dg/llvm/ValueRelations/StructureElements.h
@@ -60,11 +60,12 @@ struct Precondition {
 };
 
 struct BorderValue {
-    const llvm::Argument *from;
     size_t id;
+    const llvm::Argument *from;
+    const llvm::Value *stored;
 
-    BorderValue(const llvm::Argument *f, size_t i)
-            : from(f), id(i) {}
+    BorderValue(size_t i, const llvm::Argument *f, const llvm::Value *s)
+            : id(i), from(f), stored(s) {}
 };
 
 } // namespace vr

--- a/include/dg/llvm/ValueRelations/StructureElements.h
+++ b/include/dg/llvm/ValueRelations/StructureElements.h
@@ -1,0 +1,65 @@
+#ifndef DG_LLVM_VALUE_RELATION_STRUCTURE_ELEMENTS_H_
+#define DG_LLVM_VALUE_RELATION_STRUCTURE_ELEMENTS_H_
+
+#include <llvm/IR/Value.h>
+
+#include "GraphElements.h"
+
+namespace dg {
+namespace vr {
+
+struct AllocatedSizeView {
+    const llvm::Value *elementCount = nullptr;
+    uint64_t elementSize = 0; // in bytes
+
+    AllocatedSizeView() = default;
+    AllocatedSizeView(const llvm::Value *count, uint64_t size)
+            : elementCount(count), elementSize(size) {}
+};
+
+class AllocatedArea {
+    const llvm::Value *ptr;
+    // used only if memory was allocated with realloc, as fallback when realloc
+    // fails
+    const llvm::Value *reallocatedPtr = nullptr;
+    AllocatedSizeView originalSizeView;
+
+  public:
+    static const llvm::Value *stripCasts(const llvm::Value *inst);
+
+    static uint64_t getBytes(const llvm::Type *type);
+
+    AllocatedArea(const llvm::AllocaInst *alloca);
+
+    AllocatedArea(const llvm::CallInst *call);
+
+    const llvm::Value *getPtr() const { return ptr; }
+    const llvm::Value *getReallocatedPtr() const { return reallocatedPtr; }
+
+    std::vector<AllocatedSizeView> getAllocatedSizeViews() const;
+
+#ifndef NDEBUG
+    void ddump() const;
+#endif
+};
+
+struct CallRelation {
+    std::vector<std::pair<const llvm::Argument *, const llvm::Value *>>
+            equalPairs;
+    VRLocation *callSite = nullptr;
+};
+
+struct Precondition {
+    const llvm::Argument *arg;
+    Relations::Type rel;
+    const llvm::Value *val;
+
+    Precondition(const llvm::Argument *a, Relations::Type r,
+                 const llvm::Value *v)
+            : arg(a), rel(r), val(v) {}
+};
+
+} // namespace vr
+} // namespace dg
+
+#endif // DG_LLVM_VALUE_RELATION_STRUCTURE_ELEMENTS_H_

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -466,8 +466,8 @@ struct ValueRelations {
     const std::vector<bool> &getValidAreas() const { return validAreas; }
 
     // ************************** placeholder ***************************** //
-    Handle newPlaceholderBucket() {
-        Handle h = graph.getNewBucket();
+    Handle newBorderBucket(size_t id) {
+        Handle h = graph.getBorderBucket(id);
         bucketToVals[h];
         return h;
     }
@@ -489,8 +489,6 @@ struct ValueRelations {
     static bool compare(C lt, Relations::Type rel, C rt);
     static bool compare(C lt, Relations rels, C rt);
     static Relations compare(C lt, C rt);
-    HandlePtr getCorrespondingBorder(const ValueRelations &other,
-                                     Handle otherH);
     bool merge(const ValueRelations &other, Relations relations = allRelations);
     bool unsetChanged() {
         bool old = changed;
@@ -498,6 +496,9 @@ struct ValueRelations {
         return old;
     }
     bool holdsAnyRelations() const;
+
+    HandlePtr getBorderH(size_t id) const;
+    size_t getBorderId(Handle h) const;
 
 #ifndef NDEBUG
     void dump(ValueRelations::Handle h, std::ostream &out = std::cerr) const;

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -500,6 +500,8 @@ struct ValueRelations {
     bool holdsAnyRelations() const;
 
 #ifndef NDEBUG
+    void dump(ValueRelations::Handle h, std::ostream &out = std::cerr) const;
+    void dotDump(std::ostream &out = std::cerr) const;
     friend std::ostream &operator<<(std::ostream &out,
                                     const ValueRelations &vr);
 #endif

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -261,6 +261,23 @@ struct ValueRelations {
     // ****************************** get ********************************* //
     Handle getHandle(V val) const;
 
+    template <typename I>
+    const I *getInstance(V v) const {
+        HandlePtr mH = maybeGet(v);
+        if (!mH)
+            return llvm::dyn_cast<I>(v);
+        return getInstance<I>(*mH);
+    }
+
+    template <typename I>
+    const I *getInstance(Handle h) const {
+        for (const auto *val : getEqual(h)) {
+            if (const auto *inst = llvm::dyn_cast<I>(val))
+                return inst;
+        }
+        return nullptr;
+    }
+
     // ****************************** set ********************************* //
     template <typename X, typename Y>
     void set(const X &lt, Relations::Type rel, const Y &rt) {

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -331,7 +331,7 @@ struct ValueRelations {
     }
     template <typename X, typename Y>
     bool are(const X &lt, Relations rels, const Y &rt) const {
-        return _between(lt, rt) == rels;
+        return (_between(lt, rt) & rels) == rels;
     }
     template <typename X, typename Y>
     bool are(const X &lt, Relations::Type rel, const Y &rt) const {

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -466,6 +466,12 @@ struct ValueRelations {
     const std::vector<bool> &getValidAreas() const { return validAreas; }
 
     // ************************** placeholder ***************************** //
+    Handle newPlaceholderBucket() {
+        Handle h = graph.getNewBucket();
+        bucketToVals[h];
+        return h;
+    }
+
     template <typename X>
     Handle newPlaceholderBucket(const X &from) {
         HandlePtr mH = maybeGet(from);
@@ -483,6 +489,8 @@ struct ValueRelations {
     static bool compare(C lt, Relations::Type rel, C rt);
     static bool compare(C lt, Relations rels, C rt);
     static Relations compare(C lt, C rt);
+    HandlePtr getCorrespondingBorder(const ValueRelations &other,
+                                     Handle otherH);
     bool merge(const ValueRelations &other, Relations relations = allRelations);
     bool unsetChanged() {
         bool old = changed;

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -412,7 +412,8 @@ struct ValueRelations {
     RelGraph::RelationsMap getRelated(const X &val,
                                       const Relations &rels) const {
         HandlePtr mH = maybeGet(val);
-        assert(mH);
+        if (!mH)
+            return {};
         return graph.getRelated(*mH, rels);
     }
 

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -48,6 +48,7 @@ struct ValueRelations {
     HandlePtr maybeGet(V val) const;
 
     static std::pair<BRef, bool> get(Handle h) { return {h, false}; }
+    std::pair<BRef, bool> get(size_t id);
     std::pair<BRef, bool> get(V val);
 
     V getAny(Handle h) const;
@@ -86,20 +87,13 @@ struct ValueRelations {
     Relations _between(V lt, Handle rt) const;
     Relations _between(C lt, Handle rt) const;
     Relations _between(V lt, V rt) const;
-
-    // ************************** general has ***************************** //
     template <typename X>
-    bool has(const X &val, Relations::Type rel) const {
-        HandlePtr mVal = maybeGet(val);
-        return mVal && mVal->hasRelation(rel);
+    Relations _between(size_t lt, const X &rt) const {
+        HandlePtr mH = getBorderH(lt);
+        return mH ? _between(*mH, rt) : Relations();
     }
-    template <typename X>
-    bool has(const X &val, Relations rels) const {
-        HandlePtr mVal = maybeGet(val);
-        return mVal && ((rels.has(Relations::EQ) &&
-                         bucketToVals.find(*mVal)->second.size() > 1) ||
-                        mVal->hasAnyRelation(rels.set(Relations::EQ, false)));
-    }
+    Relations _between(Handle lt, size_t rt) const;
+    Relations _between(V lt, size_t rt) const;
 
     // *************************** iterators ***************************** //
     class RelatedValueIterator {
@@ -365,6 +359,18 @@ struct ValueRelations {
     }
 
     // ****************************** has ********************************* //
+    template <typename X>
+    bool has(const X &val, Relations::Type rel) const {
+        HandlePtr mVal = maybeGet(val);
+        return mVal && mVal->hasRelation(rel);
+    }
+    template <typename X>
+    bool has(const X &val, Relations rels) const {
+        HandlePtr mVal = maybeGet(val);
+        return mVal && ((rels.has(Relations::EQ) &&
+                         bucketToVals.find(*mVal)->second.size() > 1) ||
+                        mVal->hasAnyRelation(rels.set(Relations::EQ, false)));
+    }
     template <typename X>
     bool hasLoad(const X &from) const {
         return has(from, Relations::PT);

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -295,7 +295,7 @@ struct ValueRelations {
         Relations::Type rel = rels.get();
         set(lt, rel, rt);
         Relations other = rels & Relations().ult().ule().ugt().uge();
-        if (other.any() && other.get() != rel)
+        if (other.any() && !Relations().set(rel).addImplied().has(other.get()))
             set(lt, other.get(), rt);
     }
     template <typename X, typename Y>

--- a/include/dg/llvm/ValueRelations/ValueRelations.h
+++ b/include/dg/llvm/ValueRelations/ValueRelations.h
@@ -253,7 +253,7 @@ struct ValueRelations {
     using plain_iterator = PlainValueIterator;
 
     // ****************************** get ********************************* //
-    Handle getHandle(V val) const;
+    HandlePtr getHandle(V val) const;
 
     template <typename I>
     const I *getInstance(V v) const {

--- a/include/dg/llvm/ValueRelations/getValName.h
+++ b/include/dg/llvm/ValueRelations/getValName.h
@@ -18,6 +18,11 @@ inline std::string getValName(const llvm::Value *val) {
     ro.flush();
 
     std::string result = ostr.str();
+    size_t quote = result.find("\"");
+    while (quote != std::string::npos) {
+        result.replace(quote, 1, "\\\"");
+        quote = result.find("\"", quote + 2);
+    }
     size_t start = result.find_first_not_of(" ");
     assert(start != std::string::npos);
 

--- a/lib/llvm/ValueRelations/GraphElements.cpp
+++ b/lib/llvm/ValueRelations/GraphElements.cpp
@@ -143,8 +143,9 @@ VRCodeGraph::lazy_dfs_begin(const llvm::Function &f) const {
     return LazyDFS(f, &getEntryLocation(f), Dir::FORWARD);
 }
 
-VRCodeGraph::LazyDFS VRCodeGraph::lazy_dfs_begin(const llvm::Function &f,
-                                                 VRLocation &start) const {
+VRCodeGraph::LazyDFS
+VRCodeGraph::lazy_dfs_begin(const llvm::Function &f,
+                            const VRLocation &start) const {
     assert(categorizedEdges);
     return LazyDFS(f, &start, Dir::FORWARD);
 }
@@ -155,10 +156,15 @@ VRCodeGraph::SimpleDFS VRCodeGraph::dfs_begin(const llvm::Function &f) const {
     return SimpleDFS(f, &getEntryLocation(f), Dir::FORWARD);
 }
 
+VRCodeGraph::SimpleDFS VRCodeGraph::dfs_begin(const llvm::Function &f,
+                                              const VRLocation &start) const {
+    return SimpleDFS(f, &start, Dir::FORWARD);
+}
+
 VRCodeGraph::SimpleDFS VRCodeGraph::dfs_end() { return SimpleDFS(); }
 
 VRCodeGraph::SimpleDFS VRCodeGraph::backward_dfs_begin(const llvm::Function &f,
-                                                       VRLocation &start) {
+                                                       const VRLocation &start) {
     return SimpleDFS(f, &start, Dir::BACKWARD);
 }
 

--- a/lib/llvm/ValueRelations/GraphElements.cpp
+++ b/lib/llvm/ValueRelations/GraphElements.cpp
@@ -163,8 +163,9 @@ VRCodeGraph::SimpleDFS VRCodeGraph::dfs_begin(const llvm::Function &f,
 
 VRCodeGraph::SimpleDFS VRCodeGraph::dfs_end() { return SimpleDFS(); }
 
-VRCodeGraph::SimpleDFS VRCodeGraph::backward_dfs_begin(const llvm::Function &f,
-                                                       const VRLocation &start) {
+VRCodeGraph::SimpleDFS
+VRCodeGraph::backward_dfs_begin(const llvm::Function &f,
+                                const VRLocation &start) {
     return SimpleDFS(f, &start, Dir::BACKWARD);
 }
 

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -919,6 +919,7 @@ bool RelationsAnalyzer::passFunction(const llvm::Function &function,
                 std::cerr << location.getPredLocation(i)->relations << "\n";
             }
             std::cerr << "before\n" << location.relations << "\n";
+            std::cerr << "inside\n";
         }
 #endif
 

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -226,6 +226,13 @@ void RelationsAnalyzer::gepGen(ValueRelations &graph,
     if (gep->hasAllZeroIndices())
         graph.setEqual(gep, gep->getPointerOperand());
 
+    if (const auto *i = llvm::dyn_cast<llvm::ConstantInt>(gep->getOperand(1))) {
+        if (i->isOne())
+            graph.set(gep->getPointerOperand(), Relations::SLT, gep);
+        else if (i->isMinusOne())
+            graph.set(gep->getPointerOperand(), Relations::SGT, gep);
+    }
+
     for (auto it = graph.begin_buckets(Relations().pt());
          it != graph.end_buckets(); ++it) {
         for (V from : graph.getEqual(it->from())) {

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -792,7 +792,10 @@ void RelationsAnalyzer::inferFromNonEquality(VRLocation &join, V from,
         bool direct;
         std::tie(compared, direct) = getCompared(
                 codeGraph.getVRLocation(icmp).relations, icmp, from);
-        if (!compared)
+        if (!compared ||
+            (!llvm::isa<llvm::Constant>(compared) &&
+             !codeGraph.getVRLocation(icmp)
+                      .relations.getInstance<llvm::Argument>(compared)))
             return;
 
         assert(!initial.empty());
@@ -826,7 +829,7 @@ void RelationsAnalyzer::inferFromNonEquality(VRLocation &join, V from,
             if (structure.hasBorderValues(func)) {
                 for (const auto &borderVal :
                      structure.getBorderValuesFor(func)) {
-                    if (borderVal.from == arg) {
+                    if (borderVal.from == arg && borderVal.stored == compared) {
                         auto thisBorderPlaceholder =
                                 join.relations.getBorderH(borderVal.id);
                         join.relations.set(placeholder,

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -1127,13 +1127,9 @@ bool RelationsAnalyzer::passFunction(const llvm::Function &function,
         const bool cond = location.id == 91;
         if (print && cond) {
             std::cerr << "LOCATION " << location.id << "\n";
-            for (VREdge *predEdge : location.predecessors) {
-                std::cerr << predEdge->op->toStr() << "\n";
-            }
-        }
-        if (print && cond) {
             for (unsigned i = 0; i < location.predsSize(); ++i) {
-                std::cerr << "pred" << i << "\n";
+                std::cerr << "pred" << i << " "
+                          << location.getPredEdge(i)->op->toStr() << "\n";
                 std::cerr << location.getPredLocation(i)->relations << "\n";
             }
             std::cerr << "before\n" << location.relations << "\n";
@@ -1151,9 +1147,9 @@ bool RelationsAnalyzer::passFunction(const llvm::Function &function,
 
         bool locationChanged = location.relations.unsetChanged();
 #ifndef NDEBUG
-        if (print && cond /*&& locationChanged*/) {
+        if (print && cond && locationChanged) {
             std::cerr << "after\n" << location.relations;
-            return false;
+            // return false;
         }
 #endif
         changed |= locationChanged;
@@ -1171,7 +1167,7 @@ unsigned RelationsAnalyzer::analyze(unsigned maxPass) {
         bool changed = true;
         unsigned passNum = 0;
         while (changed && passNum < maxPass) {
-            changed = passFunction(function, false); // passNum+1==maxPass);
+            changed = passFunction(function, false); // passNum + 1 == maxPass);
             ++passNum;
         }
 

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -989,6 +989,13 @@ void RelationsAnalyzer::rememberValidated(const ValueRelations &prev,
                 for (V to : prev.getEqual(it->to()))
                     graph.set(from, Relations::PT, to);
             }
+            if (const auto *store = llvm::dyn_cast<llvm::StoreInst>(inst)) {
+                if (prev.are(it->to(), Relations::EQ,
+                             store->getValueOperand())) {
+                    for (V to : prev.getEqual(it->to()))
+                        graph.set(from, Relations::PT, to);
+                }
+            }
         }
 
         if (prev.getEqual(it->from()).empty() &&

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -162,18 +162,6 @@ bool RelationsAnalyzer::mayOverwrite(I inst, V address) const {
 }
 
 // ************************ operation helpers ************************* //
-void RelationsAnalyzer::solvesDiffOne(ValueRelations &graph, V param,
-                                      const llvm::BinaryOperator *op,
-                                      Relations::Type rel) {
-    std::vector<V> sample =
-            graph.getDirectlyRelated(param, Relations().set(rel));
-
-    for (V val : sample) {
-        assert(graph.are(param, rel, val));
-        graph.set(op, Relations::getNonStrict(rel), val);
-    }
-}
-
 bool RelationsAnalyzer::operandsEqual(
         ValueRelations &graph, I fst, I snd,
         bool sameOrder) { // false means checking in reverse order

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -588,7 +588,7 @@ bool RelationsAnalyzer::findEqualBorderBucket(const ValueRelations &relations,
 
     const auto *func = comparedI->getFunction();
     assert(structure.hasBorderValues(func));
-    const BorderValue &bv = structure.getBorderValueFor(func, mBorderId);
+    BorderValue bv = structure.getBorderValueFor(func, mBorderId);
     for (const auto &borderVal : structure.getBorderValuesFor(func)) {
         if (borderVal.from == arg && borderVal.stored == bv.stored) {
             assert(codeGraph.getVRLocation(comparedI).join);
@@ -1289,8 +1289,10 @@ bool RelationsAnalyzer::passFunction(const llvm::Function &function,
 
         bool locationChanged = location.relations.unsetChanged();
 #ifndef NDEBUG
-        if (print && cond && locationChanged) {
-            std::cerr << "after\n" << location.relations;
+        if (print && cond) {
+            std::cerr << "after\n";
+            if (locationChanged)
+                std::cerr << location.relations;
             // return false;
         }
 #endif

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -1121,7 +1121,8 @@ void RelationsAnalyzer::processOperation(VRLocation *source, VRLocation *target,
             shouldMerge = processAssumeEqual(source->relations, newGraph,
                                              static_cast<VRAssumeEqual *>(op));
         if (shouldMerge) {
-            bool result = newGraph.merge(source->relations);
+            __attribute__((unused)) bool result =
+                    newGraph.merge(source->relations);
             assert(result);
         }
 
@@ -1133,7 +1134,7 @@ void RelationsAnalyzer::processOperation(VRLocation *source, VRLocation *target,
 }
 
 bool RelationsAnalyzer::passFunction(const llvm::Function &function,
-                                     bool print) {
+                                     __attribute__((unused)) bool print) {
     bool changed = false;
 
     for (auto it = codeGraph.lazy_dfs_begin(function);

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -464,7 +464,8 @@ void RelationsAnalyzer::solveDifferent(ValueRelations &graph,
         }
 
         auto boundC = graph.getBound(param, Relations::getNonStrict(shift));
-        if (boundC.first && boundC.second.has(Relations::getNonStrict(shift))) {
+        if (boundC.first && boundC.second.has(Relations::getNonStrict(shift)) &&
+            !graph.are(op, Relations::getNonStrict(shift), boundC.first)) {
             int64_t intC = boundC.first->getSExtValue();
             intC += shift == Relations::SLT ? 1 : -1;
             const auto *newBound =

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -836,7 +836,7 @@ void RelationsAnalyzer::inferFromNonEquality(VRLocation &join, V from,
             }
         }
 
-        auto id = structure.addBorderValue(func, arg);
+        auto id = structure.addBorderValue(func, arg, compared);
         Handle entryBorderPlaceholder = entryRels.newBorderBucket(id);
         entryRels.set(entryBorderPlaceholder, Relations::PT, compared);
         entryRels.set(entryBorderPlaceholder,

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -1029,7 +1029,6 @@ void RelationsAnalyzer::processOperation(VRLocation *source, VRLocation *target,
         processInstruction(newGraph, inst);
 
     } else if (op->isAssume()) {
-        newGraph.merge(source->relations, Relations().pt());
         bool shouldMerge;
         if (op->isAssumeBool())
             shouldMerge = processAssumeBool(source->relations, newGraph,
@@ -1037,9 +1036,10 @@ void RelationsAnalyzer::processOperation(VRLocation *source, VRLocation *target,
         else // isAssumeEqual
             shouldMerge = processAssumeEqual(source->relations, newGraph,
                                              static_cast<VRAssumeEqual *>(op));
-        if (shouldMerge)
-            newGraph.merge(source->relations, comparative);
-
+        if (shouldMerge) {
+            bool result = newGraph.merge(source->relations);
+            assert(result);
+        }
     } else { // else op is noop
         newGraph.merge(source->relations, allRelations);
     }

--- a/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/RelationsAnalyzer.cpp
@@ -438,20 +438,21 @@ void RelationsAnalyzer::solveDifferent(ValueRelations &graph,
     if (canShift(graph, param, shift)) {
         graph.set(param, shift, op);
 
+        std::vector<V> sample =
+                graph.getDirectlyRelated(param, Relations().set(shift));
+
+        for (V val : sample) {
+            assert(graph.are(param, shift, val));
+            graph.set(op, Relations::getNonStrict(shift), val);
+        }
+
         auto boundC = graph.getBound(param, Relations::getNonStrict(shift));
-        if (boundC.first) {
-            if (boundC.second.has(shift))
-                graph.set(op, Relations::getNonStrict(shift), boundC.first);
-            else {
-                int64_t intC = boundC.first->getSExtValue();
-                if (shift == Relations::SLT)
-                    intC += 1;
-                else
-                    intC -= 1;
-                const auto *newBound = llvm::ConstantInt::get(
-                        boundC.first->getType(), intC, true);
-                graph.set(op, Relations::getNonStrict(shift), newBound);
-            }
+        if (boundC.first && boundC.second.has(Relations::getNonStrict(shift))) {
+            int64_t intC = boundC.first->getSExtValue();
+            intC += shift == Relations::SLT ? 1 : -1;
+            const auto *newBound =
+                    llvm::ConstantInt::get(boundC.first->getType(), intC, true);
+            graph.set(op, Relations::getNonStrict(shift), newBound);
         }
     }
 }

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -850,8 +850,7 @@ void StructureAnalyzer::dumpBorderValues(std::ostream &out) const {
             out << "("
                 << "id " << bv.id << ", "
                 << "from " << debug::getValName(bv.from) << ", "
-                << "stored " << debug::getValName(bv.stored)
-                << "), ";
+                << "stored " << debug::getValName(bv.stored) << "), ";
     }
     out << "\n]\n";
 }

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -689,7 +689,7 @@ void StructureAnalyzer::initializeCallRelations() {
             // set formal parameters equal to real
             unsigned argCount = 0;
             for (const llvm::Argument &formalArg : function.args()) {
-                if (argCount > call->getNumArgOperands())
+                if (argCount >= call->getNumArgOperands())
                     break;
                 const llvm::Value *realArg = call->getArgOperand(argCount);
 

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -769,19 +769,17 @@ StructureAnalyzer::getCallRelationsFor(const llvm::Instruction *inst) const {
 }
 
 void StructureAnalyzer::addPrecondition(const llvm::Function *func,
-                                        const llvm::Value *lt,
+                                        const llvm::Argument *lt,
                                         Relations::Type rel,
                                         const llvm::Value *rt) {
-    Precondition p{lt, rel, rt};
-    VectorSet<Precondition> vec{std::move(p)};
-    preconditionsMap.emplace(func, std::move(vec));
+    preconditionsMap[func].emplace_back(lt, rel, rt);
 }
 
 bool StructureAnalyzer::hasPreconditions(const llvm::Function *func) const {
     return preconditionsMap.find(func) != preconditionsMap.end();
 }
 
-const VectorSet<Precondition> &
+const std::vector<Precondition> &
 StructureAnalyzer::getPreconditionsFor(const llvm::Function *func) const {
     assert(preconditionsMap.find(func) != preconditionsMap.end());
     return preconditionsMap.find(func)->second;

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -785,5 +785,21 @@ StructureAnalyzer::getPreconditionsFor(const llvm::Function *func) const {
     return preconditionsMap.find(func)->second;
 }
 
+void StructureAnalyzer::addBorderValue(const llvm::Function *func,
+                                       const llvm::Argument *from,
+                                       const ValueRelations::Handle &h) {
+    borderValues[func].emplace_back(from, h);
+}
+
+bool StructureAnalyzer::hasBorderValues(const llvm::Function *func) const {
+    return borderValues.find(func) != borderValues.end();
+}
+
+const std::vector<BorderValue> &
+StructureAnalyzer::getBorderValuesFor(const llvm::Function *func) const {
+    assert(hasBorderValues(func));
+    return borderValues.find(func)->second;
+}
+
 } // namespace vr
 } // namespace dg

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -831,9 +831,8 @@ StructureAnalyzer::getBorderValuesFor(const llvm::Function *func) const {
     return borderValues.find(func)->second;
 }
 
-const BorderValue &
-StructureAnalyzer::getBorderValueFor(const llvm::Function *func,
-                                     size_t id) const {
+BorderValue StructureAnalyzer::getBorderValueFor(const llvm::Function *func,
+                                                 size_t id) const {
     for (const auto &bv : getBorderValuesFor(func)) {
         if (bv.id == id)
             return bv;

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -762,10 +762,12 @@ StructureAnalyzer::getPreconditionsFor(const llvm::Function *func) const {
     return preconditionsMap.find(func)->second;
 }
 
-void StructureAnalyzer::addBorderValue(const llvm::Function *func,
-                                       const llvm::Argument *from,
-                                       const ValueRelations::Handle &h) {
-    borderValues[func].emplace_back(from, h);
+size_t StructureAnalyzer::addBorderValue(const llvm::Function *func,
+                                       const llvm::Argument *from) {
+    auto &borderVals = borderValues[func];
+    auto id = borderVals.size();
+    borderVals.emplace_back(from, id);
+    return id;
 }
 
 bool StructureAnalyzer::hasBorderValues(const llvm::Function *func) const {
@@ -776,6 +778,14 @@ const std::vector<BorderValue> &
 StructureAnalyzer::getBorderValuesFor(const llvm::Function *func) const {
     assert(hasBorderValues(func));
     return borderValues.find(func)->second;
+}
+
+const llvm::Argument *StructureAnalyzer::getBorderArgumentFor(const llvm::Function *func, size_t id) const {
+    for (const auto& bv : getBorderValuesFor(func)) {
+        if (bv.id == id)
+            return bv.from;
+    }
+    return nullptr;
 }
 
 } // namespace vr

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -241,7 +241,6 @@ void StructureAnalyzer::findLoops() {
 
                 if (&source != &location && (!source.join || location.join))
                     source.join = &location;
-
             }
         }
     }
@@ -763,10 +762,11 @@ StructureAnalyzer::getPreconditionsFor(const llvm::Function *func) const {
 }
 
 size_t StructureAnalyzer::addBorderValue(const llvm::Function *func,
-                                       const llvm::Argument *from) {
+                                         const llvm::Argument *from,
+                                         const llvm::Value *stored) {
     auto &borderVals = borderValues[func];
     auto id = borderVals.size();
-    borderVals.emplace_back(from, id);
+    borderVals.emplace_back(id, from, stored);
     return id;
 }
 
@@ -780,8 +780,10 @@ StructureAnalyzer::getBorderValuesFor(const llvm::Function *func) const {
     return borderValues.find(func)->second;
 }
 
-const llvm::Argument *StructureAnalyzer::getBorderArgumentFor(const llvm::Function *func, size_t id) const {
-    for (const auto& bv : getBorderValuesFor(func)) {
+const llvm::Argument *
+StructureAnalyzer::getBorderArgumentFor(const llvm::Function *func,
+                                        size_t id) const {
+    for (const auto &bv : getBorderValuesFor(func)) {
         if (bv.id == id)
             return bv.from;
     }

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -831,14 +831,15 @@ StructureAnalyzer::getBorderValuesFor(const llvm::Function *func) const {
     return borderValues.find(func)->second;
 }
 
-const llvm::Argument *
-StructureAnalyzer::getBorderArgumentFor(const llvm::Function *func,
-                                        size_t id) const {
+const BorderValue &
+StructureAnalyzer::getBorderValueFor(const llvm::Function *func,
+                                     size_t id) const {
     for (const auto &bv : getBorderValuesFor(func)) {
         if (bv.id == id)
-            return bv.from;
+            return bv;
     }
-    return nullptr;
+    assert(0 && "unreachable");
+    abort();
 }
 
 #ifndef NDEBUG

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -790,5 +790,21 @@ StructureAnalyzer::getBorderArgumentFor(const llvm::Function *func,
     return nullptr;
 }
 
+#ifndef NDEBUG
+void StructureAnalyzer::dumpBorderValues(std::ostream &out) const {
+    out << "[ \n";
+    for (auto &foo : borderValues) {
+        out << "    " << foo.first->getName().str() << ": ";
+        for (auto &bv : foo.second)
+            out << "("
+                << "id " << bv.id << ", "
+                << "from " << debug::getValName(bv.from) << ", "
+                << "stored " << debug::getValName(bv.stored)
+                << "), ";
+    }
+    out << "\n]\n";
+}
+#endif
+
 } // namespace vr
 } // namespace dg

--- a/lib/llvm/ValueRelations/StructureAnalyzer.cpp
+++ b/lib/llvm/ValueRelations/StructureAnalyzer.cpp
@@ -238,6 +238,10 @@ void StructureAnalyzer::findLoops() {
                     } else
                         location.loopEnds.emplace_back(edge);
                 }
+
+                if (&source != &location && (!source.join || location.join))
+                    source.join = &location;
+
             }
         }
     }

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -441,7 +441,7 @@ void ValueRelations::dotDump(std::ostream &out) const {
     out << "digraph G {\n";
     for (auto it = begin_buckets(Relations().eq().slt().sle().ult().ule().pt());
          it != end_buckets(); ++it) {
-        out << "  RNODE" << it->from().id << " [label=\"";
+        out << "  RNODE" << it->from().id << " [label=\"" << it->from().id << ": ";
         dump(it->from(), out);
         out << "\"]; ";
         if (it->rel() != Relations::EQ)
@@ -468,6 +468,7 @@ std::ostream &operator<<(std::ostream &out, const ValueRelations &vr) {
         vr.dump(edge.to(), out);
         out << "\n";
     }
+    vr.graph.dumpBorderBuckets(out);
     return out;
 }
 #endif

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -7,7 +7,13 @@ namespace vr {
 
 // *********************** general between *************************** //
 Relations ValueRelations::_between(Handle lt, Handle rt) const {
-    return graph.getRelated(lt, allRelations)[rt];
+    Relations result = graph.getRelated(lt, allRelations)[rt];
+    if (result.any())
+        return result;
+    result = _between(lt, getInstance<llvm::ConstantInt>(rt));
+    if (result.any())
+        return result;
+    return _between(getInstance<llvm::ConstantInt>(lt), rt);
 }
 Relations ValueRelations::_between(Handle lt, V rt) const {
     HandlePtr mRt = maybeGet(rt);
@@ -387,12 +393,6 @@ std::pair<ValueRelations::BRef, bool> ValueRelations::add(V val, Handle h) {
                 graph.addRelation(h, Relations::EQ, otherH);
                 assert(valToBucket.find(val) != valToBucket.end());
                 return {valToBucket.find(val)->second, true};
-            }
-
-            for (Relations::Type type : {Relations::SLT, Relations::ULT,
-                                         Relations::SGT, Relations::UGT}) {
-                if (compare(c, type, otherC))
-                    graph.addRelation(h, type, otherH);
             }
         }
     }

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -215,10 +215,8 @@ VectorSet<ValueRelations::V> ValueRelations::getValsByPtr(V from) const {
     return getEqual(*toH);
 }
 
-ValueRelations::Handle ValueRelations::getHandle(V val) const {
-    HandlePtr mH = maybeGet(val);
-    assert(mH);
-    return *mH;
+ValueRelations::HandlePtr ValueRelations::getHandle(V val) const {
+    return maybeGet(val);
 }
 
 // ************************** placeholder ***************************** //

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -60,6 +60,15 @@ Relations ValueRelations::_between(V lt, V rt) const {
     return compare(cLt, cRt);
 }
 
+Relations ValueRelations::_between(Handle lt, size_t rt) const {
+    HandlePtr mH = getBorderH(rt);
+    return mH ? _between(lt, *mH) : Relations();
+}
+Relations ValueRelations::_between(V lt, size_t rt) const {
+    HandlePtr mH = getBorderH(rt);
+    return mH ? _between(lt, *mH) : Relations();
+}
+
 // *************************** iterators ****************************** //
 ValueRelations::rel_iterator
 ValueRelations::begin_related(V val, const Relations &rels) const {
@@ -102,6 +111,11 @@ ValueRelations::RelGraph::iterator ValueRelations::end_buckets() const {
 ValueRelations::HandlePtr ValueRelations::maybeGet(V val) const {
     auto found = valToBucket.find(val);
     return (found == valToBucket.end() ? nullptr : &found->second.get());
+}
+
+std::pair<ValueRelations::BRef, bool> ValueRelations::get(size_t id) {
+    HandlePtr mH = getBorderH(id);
+    return {mH ? *mH : newBorderBucket(id), false};
 }
 
 std::pair<ValueRelations::BRef, bool> ValueRelations::get(V val) {
@@ -303,7 +317,7 @@ ValueRelations::getAndMerge(const ValueRelations &other, Handle otherH) {
 
     if (!thisH)
         return nullptr;
-    
+
     size_t borderId = other.getBorderId(otherH);
     if (borderId != std::string::npos)
         graph.makeBorderBucket(*thisH, borderId);
@@ -441,7 +455,8 @@ void ValueRelations::dotDump(std::ostream &out) const {
     out << "digraph G {\n";
     for (auto it = begin_buckets(Relations().eq().slt().sle().ult().ule().pt());
          it != end_buckets(); ++it) {
-        out << "  RNODE" << it->from().id << " [label=\"" << it->from().id << ": ";
+        out << "  RNODE" << it->from().id << " [label=\"" << it->from().id
+            << ": ";
         dump(it->from(), out);
         out << "\"]; ";
         if (it->rel() != Relations::EQ)

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -269,8 +269,6 @@ ValueRelations::getCorrespondingBorder(const ValueRelations &other,
         for (auto thisRel : getRelated(arg, otherRel.second.invert())) {
             if (getEqual(thisRel.first).empty() &&
                 !has(thisRel.first, Relations::PF)) {
-                // if (result)
-                //     return nullptr;
                 assert(!result);
                 result = &thisRel.first.get();
             }
@@ -346,16 +344,14 @@ bool ValueRelations::merge(const ValueRelations &other, Relations relations) {
         HandlePtr thisToH = getAndMerge(other, edge.to());
         HandlePtr thisFromH = getCorresponding(other, edge.from());
 
-        if (!thisToH || !thisFromH) {
+        if (!thisToH || !thisFromH ||
+            graph.haveConflictingRelation(*thisFromH, edge.rel(), *thisToH)) {
             noConflict = false;
             continue;
         }
 
-        if (!graph.haveConflictingRelation(*thisFromH, edge.rel(), *thisToH)) {
-            bool ch = graph.addRelation(*thisFromH, edge.rel(), *thisToH);
-            updateChanged(ch);
-        } else
-            noConflict = false;
+        bool ch = graph.addRelation(*thisFromH, edge.rel(), *thisToH);
+        updateChanged(ch);
     }
     return noConflict;
 }

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -303,6 +303,10 @@ ValueRelations::getAndMerge(const ValueRelations &other, Handle otherH) {
 
     if (!thisH)
         return nullptr;
+    
+    size_t borderId = other.getBorderId(otherH);
+    if (borderId != std::string::npos)
+        graph.makeBorderBucket(*thisH, borderId);
 
     for (V val : otherEqual)
         add(val, *thisH);

--- a/lib/llvm/ValueRelations/ValueRelations.cpp
+++ b/lib/llvm/ValueRelations/ValueRelations.cpp
@@ -254,10 +254,40 @@ bool ValueRelations::holdsAnyRelations() const {
 }
 
 ValueRelations::HandlePtr
+ValueRelations::getCorrespondingBorder(const ValueRelations &other,
+                                       Handle otherH) {
+    HandlePtr result = nullptr;
+    for (auto otherRel : other.getRelated(otherH, Relations().sle().sge())) {
+        if (otherRel.second.has(Relations::EQ))
+            continue;
+
+        const llvm::Value *arg =
+                V(other.getInstance<llvm::Argument>(otherRel.first));
+        if (!arg)
+            continue;
+
+        for (auto thisRel : getRelated(arg, otherRel.second.invert())) {
+            if (getEqual(thisRel.first).empty() &&
+                !has(thisRel.first, Relations::PF)) {
+                // if (result)
+                //     return nullptr;
+                assert(!result);
+                result = &thisRel.first.get();
+            }
+        }
+    }
+    return result;
+}
+
+ValueRelations::HandlePtr
 ValueRelations::getCorresponding(const ValueRelations &other, Handle otherH,
                                  const VectorSet<V> &otherEqual) {
     if (otherEqual.empty()) { // other is a placeholder bucket, therefore it is
                               // pointed to from other bucket
+        if (!otherH.hasRelation(Relations::PF)) {
+            HandlePtr thisH = getCorrespondingBorder(other, otherH);
+            return thisH ? thisH : &newPlaceholderBucket();
+        }
         assert(otherH.hasRelation(Relations::PF));
         Handle otherFromH = otherH.getRelated(Relations::PF);
         HandlePtr thisFromH = getCorresponding(other, otherFromH);

--- a/tests/value-relations-test.cpp
+++ b/tests/value-relations-test.cpp
@@ -119,7 +119,7 @@ bool inferrs(Relations::Type one, Relations::Type two) {
     case Relations::UGE:
         return two == Relations::NE || two == Relations::UGT;
     case Relations::NE:
-        return nonStrict.has(two);
+        return nonStrict.has(two) || strict.has(two);
     case Relations::EQ:
     case Relations::SLT:
     case Relations::ULT:

--- a/tools/llvm-vr-dump.cpp
+++ b/tools/llvm-vr-dump.cpp
@@ -35,6 +35,9 @@ using llvm::errs;
 llvm::cl::opt<bool> todot("dot", llvm::cl::desc("Dump graph in grahviz format"),
                           llvm::cl::init(false));
 
+llvm::cl::opt<bool> joins("joins", llvm::cl::desc("Dump join informations"),
+                          llvm::cl::init(false));
+
 llvm::cl::opt<unsigned> max_iter("max-iter",
                                  llvm::cl::desc("Maximal number of iterations"),
                                  llvm::cl::init(20));
@@ -102,6 +105,9 @@ void dumpEdges(const VRCodeGraph &codeGraph) {
                 std::cout << edge(loc, *e->target) << " [color=magenta];\n";
             }
         }
+
+        if (joins && loc.join)
+            std::cout << edge(loc, *loc.join) << " [color=pink];\n";
     }
 }
 

--- a/tools/llvm-vr-dump.cpp
+++ b/tools/llvm-vr-dump.cpp
@@ -43,6 +43,71 @@ llvm::cl::opt<std::string> inputFile(llvm::cl::Positional, llvm::cl::Required,
                                      llvm::cl::desc("<input file>"),
                                      llvm::cl::init(""));
 
+std::string node(const VRLocation &loc) {
+    return "  NODE" + std::to_string(loc.id);
+}
+
+std::string node(unsigned i) { return "  DUMMY_NODE" + std::to_string(i); }
+
+template <typename N1, typename N2>
+std::string edge(const N1 &n1, const N2 &n2) {
+    return node(n1) + "  ->" + node(n2);
+}
+
+std::string edgeTypeToColor(EdgeType type) {
+    switch (type) {
+    case EdgeType::TREE:
+        return "darkgreen";
+    case EdgeType::FORWARD:
+        return "blue";
+    case EdgeType::BACK:
+        return "red";
+    case EdgeType::DEFAULT:
+        return "pink";
+    }
+    assert(0 && "unreach");
+}
+
+void dumpNodes(const VRCodeGraph &codeGraph) {
+    for (auto &loc : codeGraph) {
+        std::cout << node(loc);
+        std::cout << "[shape=box, margin=0.15, label=\"";
+        std::cout << "LOCATION " << loc.id << "\n";
+#ifndef NDEBUG
+        std::cout << loc.relations;
+#endif
+        std::cout << "  \"];\n";
+    }
+}
+
+void dumpEdges(const VRCodeGraph &codeGraph) {
+    unsigned dummyIndex = 0;
+    for (const auto &loc : codeGraph) {
+        for (const auto &succ : loc.successors) {
+            if (succ->target)
+                std::cout << edge(loc, *succ->target);
+            else {
+                std::cout << node(++dummyIndex) << "\n";
+                std::cout << edge(loc, dummyIndex);
+            }
+            std::cout << " [label=\"";
+#ifndef NDEBUG
+            succ->op->dump();
+#endif
+            std::cout << "\", color=" << edgeTypeToColor(succ->type) << "];\n";
+        }
+    }
+}
+
+void dotDump(const VRCodeGraph &codeGraph) {
+    std::cout << "digraph VR {\n";
+
+    dumpNodes(codeGraph);
+    dumpEdges(codeGraph);
+
+    std::cout << "}\n";
+}
+
 int main(int argc, char *argv[]) {
     llvm::Module *M;
     llvm::LLVMContext context;
@@ -94,53 +159,8 @@ int main(int argc, char *argv[]) {
               << "\n";
     std::cerr << "\n";
 
-    if (todot) {
-        std::cout << "digraph VR {\n";
-        for (auto &loc : codeGraph) {
-            std::cout << "  NODE" << loc.id;
-            std::cout << "[shape=box, margin=0.15, label=\"";
-            std::cout << "LOCATION " << loc.id << "\\n";
-#ifndef NDEBUG
-            std::cout << loc.relations;
-#endif
-            std::cout << "\"];\n";
-        }
-
-        unsigned dummyIndex = 0;
-        for (auto &loc : codeGraph) {
-            for (const auto &succ : loc.successors) {
-                if (succ->target)
-                    std::cout << "  NODE" << loc.id << " -> NODE"
-                              << succ->target->id;
-                else {
-                    std::cout << "DUMMY_NODE" << ++dummyIndex << "\n";
-                    std::cout << "  NODE" << loc.id << " -> DUMMY_NODE"
-                              << dummyIndex;
-                }
-                std::cout << " [label=\"";
-#ifndef NDEBUG
-                succ->op->dump();
-#endif
-                std::cout << "\", color=";
-                switch (succ->type) {
-                case EdgeType::TREE:
-                    std::cout << "darkgreen";
-                    break;
-                case EdgeType::FORWARD:
-                    std::cout << "blue";
-                    break;
-                case EdgeType::BACK:
-                    std::cout << "red";
-                    break;
-                case EdgeType::DEFAULT:
-                    std::cout << "pink";
-                    break;
-                }
-                std::cout << "];\n";
-            }
-        }
-        std::cout << "}\n";
-    }
+    if (todot)
+        dotDump(codeGraph);
 
     return 0;
 }

--- a/tools/llvm-vr-dump.cpp
+++ b/tools/llvm-vr-dump.cpp
@@ -96,6 +96,12 @@ void dumpEdges(const VRCodeGraph &codeGraph) {
 #endif
             std::cout << "\", color=" << edgeTypeToColor(succ->type) << "];\n";
         }
+
+        if (loc.isJustLoopJoin()) {
+            for (auto e : loc.loopEnds) {
+                std::cout << edge(loc, *e->target) << " [color=magenta];\n";
+            }
+        }
     }
 }
 

--- a/tools/llvm-vr-dump.cpp
+++ b/tools/llvm-vr-dump.cpp
@@ -69,6 +69,7 @@ std::string edgeTypeToColor(EdgeType type) {
         return "pink";
     }
     assert(0 && "unreach");
+    abort();
 }
 
 void dumpNodes(const VRCodeGraph &codeGraph) {


### PR DESCRIPTION
Tested on SV-COMP21_valid-memsafety category, changed no answers except for newly verified benchmarks.

Depends on VR: use fixed and refactored version #403