### PR TITLE
Fix bugs in annotator

### DIFF
--- a/include/dg/llvm/LLVMDGAssemblyAnnotationWriter.h
+++ b/include/dg/llvm/LLVMDGAssemblyAnnotationWriter.h
@@ -284,8 +284,11 @@ class LLVMDGAssemblyAnnotationWriter : public llvm::AssemblyAnnotationWriter {
                 break;
         }
 
-        if (!node)
+        if (!node) {
+            if (opts & ANNOTATE_SLICE)
+                os << "  ; x ";
             return;
+        }
 
         emitNodeAnnotations(node, os);
     }

--- a/tools/include/dg/tools/llvm-slicer.h
+++ b/tools/include/dg/tools/llvm-slicer.h
@@ -503,15 +503,22 @@ class ModuleAnnotator {
                 undefFunsBehaviorToStr(
                         options.dgOptions.DDAOptions.undefinedFunsBehavior) +
                 "'\n" + ";   * pointer analysis: ";
-        if (options.dgOptions.PTAOptions.analysisType ==
-            LLVMPointerAnalysisOptions::AnalysisType::fi)
+
+        using AnalysisType = LLVMPointerAnalysisOptions::AnalysisType;
+        switch (options.dgOptions.PTAOptions.analysisType) {
+        case AnalysisType::fi:
             module_comment += "flow-insensitive\n";
-        else if (options.dgOptions.PTAOptions.analysisType ==
-                 LLVMPointerAnalysisOptions::AnalysisType::fs)
+            break;
+        case AnalysisType::fs:
             module_comment += "flow-sensitive\n";
-        else if (options.dgOptions.PTAOptions.analysisType ==
-                 LLVMPointerAnalysisOptions::AnalysisType::inv)
+            break;
+        case AnalysisType::inv:
             module_comment += "flow-sensitive with invalidate\n";
+            break;
+        case AnalysisType::svf:
+            module_comment += "SVF\n";
+            break;
+        }
 
         module_comment += ";   * PTA field sensitivity: ";
         if (options.dgOptions.PTAOptions.fieldSensitivity == Offset::UNKNOWN)

--- a/tools/include/dg/tools/llvm-slicer.h
+++ b/tools/include/dg/tools/llvm-slicer.h
@@ -481,7 +481,7 @@ class ModuleAnnotator {
     void annotate(const std::set<LLVMNode *> *criteria = nullptr) {
         // compose name
         std::string fl(options.inputFile);
-        fl.replace(fl.end() - 3, fl.end(), "-debug.ll");
+        replace_suffix(fl, "-debug.ll");
 
         // open stream to write to
         std::ofstream ofs(fl);


### PR DESCRIPTION
* ModuleAnnotator: Use replace_suffix to not garble output file names
* ModuleAnnotator: Add support for AnalysisType::svf
* LLVMDGAssemblyAnnotationWriter: Annotate lines in sliced-off functions 