### PR TITLE
CI: Fix LLVM 13 jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,10 +58,9 @@ jobs:
           sudo apt install ccache cmake ninja-build clang-${{matrix.llvm}} \
                            llvm-${{matrix.llvm}}-dev
 
-          # FIXME: Remove when https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996551
-          # is resolved.
+          # FIXME: Remove when mlir dependency is removed from llvm-13-dev.
           if [[ "${{matrix.llvm}}" = "13" ]]; then
-            sudo apt install libomp-13-dev
+            sudo apt install libmlir-13-dev
           fi
 
       - name: Set environment

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -44,6 +44,9 @@ jobs:
           sudo apt install ccache cmake ninja-build clang-13 llvm-13-dev \
                            libz3-dev
 
+          # FIXME: Remove when mlir dependency is removed from llvm-13-dev.
+          sudo apt install libmlir-13-dev
+
       - name: Set environment
         id: env
         run: |


### PR DESCRIPTION
LLVM 13's CMake expects MLIR to be present.