### PR TITLE
Various fixes to stuff found during porting to LLVM 14.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -28,6 +28,7 @@ if (LLVM_DG)
     endif()
 
 	add_library(dgllvmslicer SHARED
+		    llvm-slicer-metadata.cpp
 		    llvm-slicer-opts.cpp
 		    llvm-slicer-utils.cpp
 		    llvm-slicer-preprocess.cpp
@@ -61,7 +62,7 @@ if (HAVE_SVF)
                                       PRIVATE ${llvm_transformutils})
 endif (HAVE_SVF)
 
-	add_executable(llvm-cda-dump llvm-cda-dump.cpp llvm-slicer-metadata.cpp)
+	add_executable(llvm-cda-dump llvm-cda-dump.cpp)
 	target_link_libraries(llvm-cda-dump PRIVATE dgllvmslicer
                                             PRIVATE dgllvmcda
 					    PRIVATE ${llvm_irreader}
@@ -79,7 +80,7 @@ endif (HAVE_SVF)
 					    PRIVATE ${llvm_irreader}
 					    )
 
-	add_executable(llvm-pta-dump llvm-pta-dump.cpp llvm-slicer-metadata.cpp)
+	add_executable(llvm-pta-dump llvm-pta-dump.cpp)
 	target_link_libraries(llvm-pta-dump PRIVATE dgllvmpta
                                             PRIVATE dgllvmslicer)
 if (HAVE_SVF)
@@ -109,7 +110,7 @@ endif (HAVE_SVF)
 
 
 
-	add_executable(llvm-dda-dump llvm-dda-dump.cpp llvm-slicer-metadata.cpp)
+	add_executable(llvm-dda-dump llvm-dda-dump.cpp)
 	target_link_libraries(llvm-dda-dump PRIVATE dgllvmdda)
 	target_link_libraries(llvm-dda-dump
                                 PRIVATE dgllvmslicer

--- a/tools/llvm-slicer-metadata.cpp
+++ b/tools/llvm-slicer-metadata.cpp
@@ -6,6 +6,8 @@
 
 #include "dg/tools/llvm-slicer-utils.h"
 
+#include <map>
+
 using MapTy = std::map<const llvm::Value *, CVariableDecl>;
 
 // create the mapping from LLVM values to C variable names


### PR DESCRIPTION
These were found during porting to LLVM 14.

* CallGraph.h: Use `isPointerOrIntegerTy` from `llvm-utils.h`
* tools/CMakeLists.txt: Add `llvm-slicer-metadata.cpp` to `libdgllvmslicer`
* tools/llvm-slicer-metadata: Fix compilation with GCC 12