### PR TITLE
Quaterly CI update

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,16 +6,14 @@ on: [push, pull_request]
 jobs:
   Format:
     name: Find unformatted files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout DG
         uses: actions/checkout@v3
 
-      - name: Install latest clang-format
+      - name: Install clang-format 14
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-          sudo apt install clang-format-13
+          sudo apt install clang-format-14
 
       - name: Find unformatted files
         # Based on https://rigtorp.se/notes/clang-format/.
@@ -24,4 +22,4 @@ jobs:
           find . -regextype posix-extended \
                  -iregex '\./(include|lib|tests|tools)/.*\.(h|c|cpp|hpp)' \
                  -o -iregex '\./tests/catch2' -prune -type f | \
-              xargs clang-format-13 --style=file --dry-run -Werror --color=true
+              xargs clang-format-14 --style=file --dry-run -Werror --color=true

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install latest clang-format
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the Docker image
         run: |

--- a/.github/workflows/hash_map.yml
+++ b/.github/workflows/hash_map.yml
@@ -7,10 +7,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04]
         compiler: [gcc, clang]
         hashmap: [tsl-hopscotch]
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{matrix.os}}
     env:
       # for colours in ninja
       CLICOLOR_FORCE: 1
@@ -71,8 +72,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ubuntu-20.04-${{matrix.hashmap}}-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
-          restore-keys: ubuntu-20.04-${{matrix.hashmap}}-${{matrix.compiler}}
+          key: ${{matrix.os}}-${{matrix.hashmap}}-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ${{matrix.os}}-${{matrix.hashmap}}-${{matrix.compiler}}
 
       - name: Configure CMake project
         run: |

--- a/.github/workflows/hash_map.yml
+++ b/.github/workflows/hash_map.yml
@@ -69,7 +69,7 @@ jobs:
           echo "::set-output name=timestamp::$(date -u -Iseconds)"
 
       - name: Set up ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{matrix.os}}-${{matrix.hashmap}}-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}

--- a/.github/workflows/hash_map.yml
+++ b/.github/workflows/hash_map.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout TSL Hopscotch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Tessil/hopscotch-map
           path: tsl-hopscotch

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '[LLVM ${{matrix.llvm}}] Add repositories'
         if: matrix.llvm >= 15

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,8 +20,8 @@ jobs:
           - {os: ubuntu-20.04, llvm: 10, compiler: gcc}
           - {os: ubuntu-20.04, llvm: 11, compiler: gcc}
           - {os: ubuntu-20.04, llvm: 12, compiler: gcc}
-          - {os: ubuntu-20.04, llvm: 13, compiler: gcc}
-          - {os: ubuntu-20.04, llvm: 13, compiler: gcc, type: Debug}
+          - {os: ubuntu-22.04, llvm: 13, compiler: gcc}
+          - {os: ubuntu-22.04, llvm: 13, compiler: gcc, type: Debug}
 
           # Linux with Clang
           - {os: ubuntu-18.04, llvm: '3.9', compiler: clang}
@@ -34,8 +34,8 @@ jobs:
           - {os: ubuntu-20.04, llvm: 10, compiler: clang}
           - {os: ubuntu-20.04, llvm: 11, compiler: clang}
           - {os: ubuntu-20.04, llvm: 12, compiler: clang}
-          - {os: ubuntu-20.04, llvm: 13, compiler: clang}
-          - {os: ubuntu-20.04, llvm: 13, compiler: clang, type: Debug}
+          - {os: ubuntu-22.04, llvm: 13, compiler: clang}
+          - {os: ubuntu-22.04, llvm: 13, compiler: clang, type: Debug}
 
     runs-on: ${{matrix.os}}
     env:
@@ -46,22 +46,17 @@ jobs:
       - name: Checkout DG
         uses: actions/checkout@v2
 
-      - name: '[LLVM 13] Add repositories'
-        if: matrix.llvm == 13
+      - name: '[LLVM ${{matrix.llvm}}] Add repositories'
+        if: matrix.llvm >= 15
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-add-repository "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{matrix.llvm}} main"
 
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install ccache cmake ninja-build clang-${{matrix.llvm}} \
                            llvm-${{matrix.llvm}}-dev
-
-          # FIXME: Remove when mlir dependency is removed from llvm-13-dev.
-          if [[ "${{matrix.llvm}}" = "13" ]]; then
-            sudo apt install libmlir-13-dev
-          fi
 
       - name: Set environment
         id: env

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,7 +94,7 @@ jobs:
           echo "::set-output name=timestamp::$(date -u -Iseconds)"
 
       - name: Set up ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{matrix.os}}-${{matrix.llvm}}-${{matrix.compiler}}-${{matrix.type}}-${{steps.env.outputs.timestamp}}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
         build: [Debug, RelWithDebInfo]
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: brew install ninja ccache

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -37,7 +37,7 @@ jobs:
           echo "::set-output name=timestamp::$(date -u +%Y-%m-%dT%H:%M:%S%z)"
 
       - name: Set-up ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{matrix.os}}-${{matrix.build}}-${{steps.env.outputs.timestamp}}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,9 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest]
         build: [Debug, RelWithDebInfo]
 
-    runs-on: macos-latest
+    runs-on: ${{matrix.os}}
     env:
       # for colours in ninja
       CLICOLOR_FORCE: 1

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         compiler: [gcc, clang]
 
     runs-on: ${{matrix.os}}
@@ -34,19 +34,11 @@ jobs:
           repository: SVF-tools/Test-Suite
           path: svf/Test-Suite
 
-      - name: '[LLVM 13] Add repositories'
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install ccache cmake ninja-build clang-13 llvm-13-dev \
                            libz3-dev
-
-          # FIXME: Remove when mlir dependency is removed from llvm-13-dev.
-          sudo apt install libmlir-13-dev
 
       - name: Set environment
         id: env

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=timestamp::$(date -u -Iseconds)"
 
       - name: Set up ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: ${{matrix.os}}-svf-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -82,6 +82,9 @@ jobs:
         run: |
           # Build directory name format is hard-coded in SVF tests...
 
+          # do not build with -Werror (needed for GCC 11.2.0)
+          sed -i 's/-Werror//' svf/CMakeLists.txt
+
           # WARNING: DO NOT SET CMAKE_BUILD_TYPE! (except Debug)
           # SVF expects that NDEBUG will never be defined!
           cmake -Ssvf \

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout DG
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout SVF
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: SVF-2.4
           repository: SVF-tools/SVF
           path: svf
 
       - name: Checkout SVF test-suite
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # ref corresponding to the SVF ref above
           ref: 2338ede904c1f46293b64ccf32feb09b3904401f

--- a/.github/workflows/svf.yml
+++ b/.github/workflows/svf.yml
@@ -7,9 +7,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04]
         compiler: [gcc, clang]
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{matrix.os}}
     env:
       # for colours in ninja
       CLICOLOR_FORCE: 1
@@ -82,8 +83,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ubuntu-20.04-svf-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
-          restore-keys: ubuntu-20.04-svf-${{matrix.compiler}}
+          key: ${{matrix.os}}-svf-${{matrix.compiler}}-${{steps.env.outputs.timestamp}}
+          restore-keys: ${{matrix.os}}-svf-${{matrix.compiler}}
 
       - name: Build SVF
         run: |


### PR DESCRIPTION
* add Ubuntu 22.04 jobs for LLVM 13 and newer
* update actions/checkout to v3
* use clang-format 14 for style checking
* use `matrix.os` even when we use only one system
* update the SVF job to use Ubuntu 22.04
* update the macOS job to macOS 12
* update actions/cache to v3