### PR TITLE
freeze support in PTA

### DIFF
--- a/include/dg/llvm/PointerAnalysis/PointerGraph.h
+++ b/include/dg/llvm/PointerAnalysis/PointerGraph.h
@@ -333,6 +333,7 @@ class LLVMPointerGraphBuilder {
     PSNodesSeq &createAlloc(const llvm::Instruction *Inst);
     PSNode *createDynamicAlloc(const llvm::CallInst *CInst,
                                AllocationFunction type);
+    PSNodesSeq &createFreeze(const llvm::Instruction *Inst);
     PSNodesSeq &createStore(const llvm::Instruction *Inst);
     PSNodesSeq &createLoad(const llvm::Instruction *Inst);
     PSNodesSeq &createGEP(const llvm::Instruction *Inst);

--- a/lib/llvm/PointerAnalysis/Instructions.cpp
+++ b/lib/llvm/PointerAnalysis/Instructions.cpp
@@ -516,5 +516,14 @@ LLVMPointerGraphBuilder::createAtomicRMW(const llvm::Instruction *Inst) {
     return addNode(Inst, ret);
 }
 
+LLVMPointerGraphBuilder::PSNodesSeq &
+LLVMPointerGraphBuilder::createFreeze(const llvm::Instruction *Inst) {
+    const llvm::Value *op = Inst->getOperand(0);
+    PSNode *op1 = getOperand(op);
+    PSNode *node = PS.create<PSNodeType::CAST>(op1);
+    assert(node);
+    return addNode(Inst, node);
+}
+
 } // namespace pta
 } // namespace dg

--- a/lib/llvm/PointerAnalysis/PointerGraph.cpp
+++ b/lib/llvm/PointerAnalysis/PointerGraph.cpp
@@ -410,6 +410,8 @@ LLVMPointerGraphBuilder::buildInstruction(const llvm::Instruction &Inst) {
                         "precision\n";
         seq = &createUnknown(&Inst);
         break;
+    case Instruction::Freeze:
+        return createFreeze(&Inst);    
     default:
         llvm::errs() << "[pta] UNHANDLED: " << Inst << "\n";
         assert(0 && "Unhandled instruction");


### PR DESCRIPTION
Hello,

I'm dabbling in some DFI and currently testing an implementation using DG on the SPEC 2006 bench-marking suite.
Unfortunately most of the programs in the benchmark contain the [freeze](https://llvm.org/docs/LangRef.html#id2230) instruction, which is not supported by dg. Because the instruction itself does nothing special, its behavior can be seen as a cast from one type to the same type. To my knowledge the instruction does not change the memory nor the any pointers.

Aside from that freeze does change poison values back to regular values. I can't think of a way this would influence the results of a PTA but if it would, I'm open to discuss any ideas to more specifically handle these poison values.

Thanks!